### PR TITLE
Avoid use of deprecated homebrew/science/numdiff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.8 libffi gettext ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.8/4.8.5/bin/gfortran-4.8 ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.9 libffi gettext ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.8 ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.8 libffi gettext ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.8/4.8.5/bin/gfortran-4.8 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.9 libffi gettext ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install gcc@4.9 libffi gettext ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install gcc@4.8 ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.8 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.8/4.8.5/bin/gfortran-4.8 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -R /usr/local/Cellar/ ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; fi
 
   install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install gcc@4.9 libffi gettext ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.9 libffi gettext ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.9 libffi gettext ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4/bin/gfortran-4.9 ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.8/4.8.5/bin/gfortran-4.8 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
-    - ./tools/install/install_numdiff.sh $PWD
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; fi
 
   install:
     - ./tools/build.sh ./tools/mcm_example.fac

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -R /usr/local/Cellar/ ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; fi
 
   install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; PATH=$PATH:$PWD/numdiff/bin ; fi
 
   install:
     - ./tools/build.sh ./tools/mcm_example.fac

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install gcc@4.8 homebrew/science/numdiff ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; brew install gcc@4.8 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.8/4.8.5/bin/gfortran-4.8 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
+    - ./tools/install/install_numdiff.sh $PWD
 
   install:
     - ./tools/build.sh ./tools/mcm_example.fac

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ FORT_COMP    = gfortran
 CVODELIB     = /home/travis/build/AtChem/AtChem2/cvode/lib
 else
 # if macOS, then pass homebrew gfortran and self-built cvode
-FORT_COMP    = /usr/local/Cellar/gcc@4.8/4.8.5/bin/gfortran-4.8
+FORT_COMP    = /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9
 CVODELIB     = /Users/travis/build/AtChem/AtChem2/cvode/lib
 endif
 # else it's not on Travis, so check the OS, and then pass local path to cvode

--- a/tools/install/install_numdiff_macOS.sh
+++ b/tools/install/install_numdiff_macOS.sh
@@ -29,6 +29,6 @@ tar -zxf numdiff-5.8.1.tar.gz
 rm numdiff-5.8.1.tar.gz
 
 cd numdiff-5.8.1/
-./configure --prefix=$1/numdiff CPPFLAGS=-I/usr/local/Cellar/gettext/0.19.8.1/include/ LDFLAGS=-L/usr/local/Cellar/gettext/0.19.8.1/libmake
+./configure --prefix=$1/numdiff CPPFLAGS=-I/usr/local/Cellar/gettext/0.19.8.1/include/ LDFLAGS=-L/usr/local/Cellar/gettext/0.19.8.1/lib
 make
 make install

--- a/tools/install/install_numdiff_macOS.sh
+++ b/tools/install/install_numdiff_macOS.sh
@@ -1,0 +1,34 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2018 Sam Cox, Roberto Sommariva
+#
+# This file is part of the AtChem2 software package.
+#
+# This file is covered by the MIT license which can be found in the file
+# LICENSE.md at the top level of the AtChem2 distribution.
+#
+# -----------------------------------------------------------------------------
+
+#!/bin/sh
+
+# This script downloads and installs NUMDIFF 5.8.1 into the directory
+# given by input argument $1. This is dependent on the existence of a
+# gcc installation.
+#
+# Example usage:
+#   ./install_numdiff_macOS.sh /path/to/install/directory
+
+if [ -z "$1" ] ; then
+  echo "Please provide an argument to tools/install/install_numdiff_macOS.sh"
+  exit 1
+fi
+cd $1
+wget http://ftp.igh.cnrs.fr/pub/nongnu/numdiff/numdiff-5.8.1.tar.gz
+
+tar -zxf numdiff-5.8.1.tar.gz
+rm numdiff-5.8.1.tar.gz
+
+cd numdiff-5.8.1/
+./configure --prefix=$1/numdiff CPPFLAGS=-I/usr/local/Cellar/gettext/0.19.8.1/include/ LDFLAGS=-L/usr/local/Cellar/gettext/0.19.8.1/libmake
+make
+make install


### PR DESCRIPTION
Travis: remove dependence on homebrew/science/numdiff. Install via bundled script instead.