### PR TITLE
Remove nested nature of readPhotolysisConstants/readPhotolysisRates

### DIFF
--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -328,6 +328,7 @@ contains
     logical :: allocated = .false.
     logical :: allocated_j = .false.
 
+    filename = trim( param_dir ) // '/photolysisConstants.config'
     write (*, '(A)') ' Reading photolysis constants from file...'
     nrOfPhotoRates = count_lines_in_file( filename, .true. )
     if ( allocated .eqv. .false. ) then

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -310,9 +310,7 @@ contains
   end subroutine setConcentrations
 
   ! -----------------------------------------------------------------
-  ! If modelConfiguration/photolysisConstants.config exists, then read
-  ! in 3 values to fill ck, cl and str. Otherwise, call
-  ! ReadPhotolysisRates to fill ck, cl, cmm, cnn, str and tf.
+  ! Read in 3 values to fill ck, cl and str.
   subroutine readPhotolysisConstants()
     use types_mod
     use photolysis_rates_mod, only : usePhotolysisConstants, nrOfPhotoRates, ck, cl, photoRateNames, &
@@ -365,7 +363,7 @@ contains
   end subroutine readPhotolysisConstants
 
   ! -----------------------------------------------------------------
-  ! This is called from readPhotolysisConstants if
+  ! This is called from readPhotoRates() if
   ! modelConfiguration/photolysisConstants.config doesn't exist. It
   ! reads ck, cl, cmm, cnn, str, and tf from
   ! modelConfiguration/photolysisRates.config.

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -328,18 +328,6 @@ contains
     logical :: allocated = .false.
     logical :: allocated_j = .false.
 
-    ! Check whether file exists correctly in readPhotolysisConstants.
-    filename = trim( param_dir ) // '/photolysisConstants.config'
-    write (*, '(A)') ' Looking for photolysis constants file...'
-    inquire(file=filename, exist=file_exists)
-    if ( file_exists .eqv. .false. ) then
-      usePhotolysisConstants = .false.
-      write (*, '(A)') ' Photolysis constants file not found, trying photolysis rates file...'
-      call readPhotolysisRates()
-      return
-    end if
-    usePhotolysisConstants = .true.
-
     write (*, '(A)') ' Reading photolysis constants from file...'
     nrOfPhotoRates = count_lines_in_file( filename, .true. )
     if ( allocated .eqv. .false. ) then
@@ -723,9 +711,22 @@ contains
     character(len=maxPhotoRateNameLength) :: string
     character(len=maxFilepathLength) :: fileLocationPrefix
     character(len=maxFilepathLength+maxPhotoRateNameLength) :: fileLocation
+    character(len=maxFilepathLength) :: filename
+    logical :: file_exists
 
     ! Get names of photo rates
-    call readPhotolysisConstants()
+    ! Check whether file exists correctly in readPhotolysisConstants.
+    filename = trim( param_dir ) // '/photolysisConstants.config'
+    write (*, '(A)') ' Looking for photolysis constants file...'
+    inquire(file=filename, exist=file_exists)
+    if ( file_exists .eqv. .true. ) then
+      usePhotolysisConstants = .true.
+      call readPhotolysisConstants()
+    else
+      usePhotolysisConstants = .false.
+      write (*, '(A)') ' Photolysis constants file not found, trying photolysis rates file...'
+      call readPhotolysisRates()
+    end if
     write (*,*)
 
     numConPhotoRates = 0


### PR DESCRIPTION
Only one of them needs to be called, based upon the existence of param_dir/photolysisConstants.config, so only call one.

This partially addresses #272, though more remains to be done.