### PR TITLE
Module variable usage edits

### DIFF
--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -26,11 +26,10 @@ PROGRAM ATCHEM2
   use constraints_mod
   use interpolation_method_mod
   use reaction_structure_mod
-  use photolysis_rates_mod
-  use zenith_data_mod
+  use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints
   use reaction_rates_mod
   use env_vars_mod
-  use date_mod
+  use date_mod, only : calcInitialDateParameters, calcCurrentDateParameters
   use directories_mod, only : output_dir, param_dir
   use storage_mod, only : maxSpecLength, maxPhotoRateNameLength
   use solver_params_mod
@@ -38,8 +37,8 @@ PROGRAM ATCHEM2
   use input_functions_mod
   use config_functions_mod
   use output_functions_mod
-  use constraint_functions_mod
-  use solver_functions_mod
+  use constraint_functions_mod, only : addConstrainedSpeciesToProbSpec, removeConstrainedSpeciesFromProbSpec
+  use solver_functions_mod, only : jfy
   implicit none
 
   ! *****************************************************************

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -29,8 +29,8 @@ contains
   ! photolysis equations, using the current zenith data values
   function calcPhotolysis( i ) result ( photolysis )
     use types_mod
-    use photolysis_rates_mod
-    use zenith_data_mod
+    use photolysis_rates_mod, only : cl, cmm, cnn, transmissionFactor
+    use zenith_data_mod, only : cosx, secx
     implicit none
 
     integer(kind=NPI), intent(in) :: i
@@ -49,8 +49,8 @@ contains
   subroutine calcJFac( t, jFac )
     use types_mod
     use zenith_data_mod
-    use photolysis_rates_mod
-    use constraints_mod
+    use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints, jFacSpecies, jFacSpeciesLine, numConPhotoRates, &
+                                     usePhotolysisConstants, constrainedPhotoRates
     use interpolation_functions_mod, only : getConstrainedQuantAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
     implicit none
@@ -186,11 +186,9 @@ contains
     use types_mod
     use storage_mod, only : maxEnvVarNameLength
     use env_vars_mod
-    use constraints_mod
-    use zenith_data_mod
     use interpolation_functions_mod, only : getConstrainedQuantAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
-    use atmosphere_functions_mod
+    use atmosphere_functions_mod, only : calcAirDensity, convertRHtoH2O
     use solar_functions_mod
     implicit none
 

--- a/src/interpolationFunctions.f90
+++ b/src/interpolationFunctions.f90
@@ -27,7 +27,8 @@ contains
   subroutine getConstrainedQuantAtT( t, x, y, dataNumberOfPoints, interpMethod, ind, concAtT )
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
-    use interpolation_method_mod
+    use interpolation_method_mod, only : getSpeciesInterpMethod, getConditionsInterpMethod, &
+                                         setSpeciesInterpMethod, setConditionsInterpMethod
     implicit none
 
     real(kind=DP), intent(in) :: t, x(:,:), y(:,:)

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -207,7 +207,6 @@ contains
   subroutine outputRates( r, arrayLen, t, p, flag )
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
-    use reaction_structure_mod
     use species_mod, only : getSpeciesList
     use storage_mod, only : maxSpecLength, maxReactionStringLength
     implicit none
@@ -265,7 +264,6 @@ contains
   subroutine outputInstantaneousRates( time )
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
-    use reaction_structure_mod
     use directories_mod, only : instantaneousRates_dir
     use reaction_rates_mod, only : instantaneousRates
     use storage_mod, only : maxFilepathLength

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -38,7 +38,7 @@ contains
   ! Write each environment variable to file
   subroutine outputEnvVar( t )
     use types_mod
-    use env_vars_mod
+    use env_vars_mod, only : envVarNames, numEnvVars, currentEnvVarValues, ro2
     implicit none
 
     real(kind=DP), intent(in) :: t
@@ -103,7 +103,7 @@ contains
   ! Write parameters used in calculation of photolysis rates to file.
   subroutine outputPhotoRateCalcParameters( t )
     use types_mod
-    use zenith_data_mod
+    use zenith_data_mod, only : latitude, longitude, secx, cosx, lha, sinld, cosld, theta, eqtime
     implicit none
 
     real(kind=DP), intent(in) :: t
@@ -145,7 +145,7 @@ contains
   ! reaction.
   pure function getReaction( speciesNames, reactionNumber ) result ( reaction )
     use types_mod
-    use reaction_structure_mod
+    use reaction_structure_mod, only : clhs, crhs
     use storage_mod, only : maxSpecLength, maxReactionStringLength
     implicit none
 

--- a/src/solarFunctions.f90
+++ b/src/solarFunctions.f90
@@ -28,7 +28,7 @@ contains
   subroutine calcTheta( t )
     use types_mod
     use date_mod, only : currentYear, currentDayOfYear
-    use zenith_data_mod
+    use zenith_data_mod, only : theta
     implicit none
 
     real(kind=DP), intent(in) :: t
@@ -58,7 +58,7 @@ contains
   ! (Environmental UV Photobiology, 1993).
   pure function calcDec() result ( dec )
     use types_mod
-    use zenith_data_mod
+    use zenith_data_mod, only : theta
     implicit none
 
     real(kind=DP) :: dec, b0, b1, b2, b3, b4, b5, b6
@@ -86,7 +86,8 @@ contains
   subroutine calcZenith( t, dec )
     use types_mod
     use date_mod, only : currentDayOfYear
-    use zenith_data_mod
+    use zenith_data_mod, only : eqtime, theta, lha, latitude, longitude, sinld, cosld, cosx, secx, cosx_threshold, &
+                                cosx_below_threshold
     implicit none
 
     real(kind=DP), intent(in) :: t, dec

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -25,7 +25,7 @@ contains
   ! Calculates the system residual
   subroutine resid( nr, time, y, dy, lhs, lcoeff, rhs, rcoeff )
     use types_mod
-    use reaction_rates_mod
+    use reaction_rates_mod, only : lossRates, productionRates, instantaneousRates
     implicit none
 
     integer(kind=NPI), intent(in) :: nr ! number of reactions

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -151,7 +151,7 @@ contains
     use types_mod
     use storage_mod, only : maxEnvVarNameLength
     use photolysis_rates_mod
-    use zenith_data_mod, only : cosx, secx, cosx_below_threshold
+    use zenith_data_mod, only : cosx_below_threshold
     use env_vars_mod, only : ro2, envVarNames, currentEnvVarValues
     use interpolation_functions_mod, only : getConstrainedQuantAtT
     use interpolation_method_mod, only : getConditionsInterpMethod


### PR DESCRIPTION
Explicitly use only some variables from zenith_data_mod in functions in solverFunctions.f90. Fix an unused module variable warning in solverFunctions.f90 introduced by #275.