### PR TITLE
Defensive programming fixes

### DIFF
--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -939,6 +939,10 @@ contains
         constrainedNames(j + numberOfVariableConstrainedSpecies) = name
         dataFixedY(j) = value
         call setConstrainedSpecies( j + numberOfVariableConstrainedSpecies, id )
+      else
+        write (stderr, '(A, A, A)') 'Supplied fixed constrained species ', &
+                                    trim( constrainedNames(i) ), ' is not a species in the problem.'
+        stop
       end if
     end do
     close (14, status='keep')

--- a/src/interpolationFunctions.f90
+++ b/src/interpolationFunctions.f90
@@ -47,10 +47,16 @@ contains
     if ( size( x, 2 ) /= size( y, 2 ) ) then
       stop 'size( x, 2 ) /= size( y, 2 ) in getConstrainedQuantAtT()'
     end if
+    if ( ind > size( x, 1 ) ) then
+      stop 'ind > size( x, 1 ) in getConstrainedQuantAtT()'
+    end if
+    if ( ind < 1 ) then
+      stop 'ind < 1 in getConstrainedQuantAtT()'
+    end if
 
     ! Find the interval in which t sits
     interp_success = .false.
-    do i = 1, dataNumberOfPoints
+    do i = 1, dataNumberOfPoints - 1
       if ( ( t >= x(ind, i) ) .and. ( t < x(ind, i+1) ) ) then
         indexBefore = i
         interp_success = .true.


### PR DESCRIPTION
Check supplied index is within bounds, fix a bug which would go outside of bounds, and output an error if a supplied species is not a member of the problem.