### PR TITLE
Photolysis reconfig

### DIFF
--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -26,7 +26,7 @@ PROGRAM ATCHEM2
   use constraints_mod
   use interpolation_method_mod
   use reaction_structure_mod
-  use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints
+  use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints, PR_type
   use reaction_rates_mod
   use env_vars_mod
   use date_mod, only : calcInitialDateParameters, calcCurrentDateParameters
@@ -511,7 +511,9 @@ PROGRAM ATCHEM2
   deallocate (envVarX, envVarY, envVarNumberOfPoints)
 
   ! deallocate arrays from module photolysis_rates_mod
-  deallocate (photoX, photoY, photoNumberOfPoints)
+  if ( PR_type == 2 .or. PR_type == 3) then
+    deallocate (photoX, photoY, photoNumberOfPoints)
+  end if
 
   ! Close output files and end program
   close (50)

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -104,11 +104,6 @@ contains
       if ( usePhotolysisConstants .eqv. .false. ) then
         if ( cosx_below_threshold .eqv. .false. ) then
           jFac = JFacSpeciesAtT / calcPhotolysisRaw( jFacL, jFacM, jFacN, jFacTransmissionFactor )
-          write (*,*) 'jfac = ', jFac, ' = ', JFacSpeciesAtT, ' / ', &
-                      calcPhotolysisRaw( jFacL, jFacM, jFacN, jFacTransmissionFactor )
-          !write (*,*) cl( jFacSpeciesLine ), cosx, cmm( jFacSpeciesLine ), -cnn( jFacSpeciesLine ), secx, &
-          !transmissionFactor( jFacSpeciesLine )
-
         else
           jFac = 0
         end if

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -49,8 +49,8 @@ contains
   subroutine calcJFac( t, jFac )
     use types_mod
     use zenith_data_mod
-    use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints, jFacSpecies, jFacSpeciesLine, numConPhotoRates, &
-                                     usePhotolysisConstants, constrainedPhotoRates
+    use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints, jFacSpecies, jFacSpeciesLine, numConstrainedPhotoRates, &
+                                     usePhotolysisConstants, constrainedPhotoNames
     use interpolation_functions_mod, only : getConstrainedQuantAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
     implicit none
@@ -68,8 +68,8 @@ contains
 
     ! GET INDEX OF basePhotoRate SPECIES IN PHOTO CONSTRAINT ARRAY
     basePhotoRateNum = 0
-    do i = 1, numConPhotoRates
-      if ( trim( constrainedPhotoRates(i) ) == trim( jFacSpecies ) ) then
+    do i = 1, numConstrainedPhotoRates
+      if ( trim( constrainedPhotoNames(i) ) == trim( jFacSpecies ) ) then
         basePhotoRateNum = i
       end if
     end do

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -31,9 +31,9 @@ contains
 
     real(kind=DP), intent(in) :: l, m, n, tf
     real(kind=DP) :: photolysis
-    write (*,*) l, m, n, tf, cosx, secx
+
     photolysis = l * cosx ** m * exp( -n * secx ) * tf
-    write (*,*) photolysis
+
     return
   end function calcPhotolysisRaw
 

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -24,6 +24,19 @@
 module constraint_functions_mod
 contains
 
+  function calcPhotolysisRaw( l, m, n, tf ) result ( photolysis )
+    use types_mod
+    use zenith_data_mod, only : cosx, secx
+    implicit none
+
+    real(kind=DP), intent(in) :: l, m, n, tf
+    real(kind=DP) :: photolysis
+    write (*,*) l, m, n, tf, cosx, secx
+    photolysis = l * cosx ** m * exp( -n * secx ) * tf
+    write (*,*) photolysis
+    return
+  end function calcPhotolysisRaw
+
   ! ----------------------------------------------------------------- !
   ! Calculate the photolysis rate of photolysis number i from the
   ! photolysis equations, using the current zenith data values
@@ -50,7 +63,8 @@ contains
     use types_mod
     use zenith_data_mod
     use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints, jFacSpecies, jFacSpeciesLine, numConstrainedPhotoRates, &
-                                     usePhotolysisConstants, constrainedPhotoNames
+                                     usePhotolysisConstants, constrainedPhotoNames, cl, cmm, cnn, transmissionFactor, &
+                                     jFacL, jFacM, jFacN, jFacTransmissionFactor
     use interpolation_functions_mod, only : getConstrainedQuantAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
     implicit none
@@ -89,7 +103,12 @@ contains
     else
       if ( usePhotolysisConstants .eqv. .false. ) then
         if ( cosx_below_threshold .eqv. .false. ) then
-          jFac = JFacSpeciesAtT / calcPhotolysis( jFacSpeciesLine )
+          jFac = JFacSpeciesAtT / calcPhotolysisRaw( jFacL, jFacM, jFacN, jFacTransmissionFactor )
+          write (*,*) 'jfac = ', jFac, ' = ', JFacSpeciesAtT, ' / ', &
+                      calcPhotolysisRaw( jFacL, jFacM, jFacN, jFacTransmissionFactor )
+          !write (*,*) cl( jFacSpeciesLine ), cosx, cmm( jFacSpeciesLine ), -cnn( jFacSpeciesLine ), secx, &
+          !transmissionFactor( jFacSpeciesLine )
+
         else
           jFac = 0
         end if

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -474,15 +474,16 @@ module photolysis_rates_mod
   implicit none
   save
 
-  integer(kind=NPI) :: numConstrainedPhotoRates
-  integer(kind=NPI), allocatable :: constrainedPhotoRatesNumbers(:), constantPhotoJNumbers(:)
+  integer(kind=NPI) :: numConstrainedPhotoRates, numUnconstrainedPhotoRates
+  integer(kind=NPI), allocatable :: constrainedPhotoRatesNumbers(:), constantPhotoJNumbers(:), unconstrainedPhotoNumbers(:)
   integer(kind=NPI) :: jFacSpeciesLine = 0_NPI ! number of line in photolysis rates file corresponding to Jfac species
-  integer(kind=NPI) :: numPhotoRates, totalNumPhotos, numConstantPhotoRates
+  integer(kind=NPI) :: totalNumPhotos, numConstantPhotoRates
   integer(kind=NPI), allocatable :: ck(:), photoNumbers(:)
-  logical :: usePhotolysisConstants, allPRsConstrained, usePhotolysisConstraints
+  logical :: usePhotolysisConstants, usePhotolysisConstraints, unconstrainedPhotosExist
   real(kind=DP), allocatable :: cl(:), cmm(:), cnn(:), transmissionFactor(:)
   real(kind=DP), allocatable :: j(:), constantPhotoValues(:)
-  character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:), constrainedPhotoNames(:), constantPhotoNames(:)
+  character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:), constrainedPhotoNames(:), constantPhotoNames(:), &
+                                                        unconstrainedPhotoNames(:)
   character(len=maxPhotoRateNameLength) :: jFacSpecies
   real(kind=DP), allocatable :: photoX(:,:), photoY(:,:)
   integer(kind=NPI), allocatable :: photoNumberOfPoints(:)
@@ -504,12 +505,13 @@ contains
     allocate (photoNumbers(totalNumPhotos))
   end subroutine allocate_photolysis_numbers_variables
 
-  subroutine allocate_photolysis_rates_variables()
+  subroutine allocate_unconstrained_photolysis_rates_variables()
     implicit none
 
-    allocate (ck(numPhotoRates), cl(numPhotoRates), cmm(numPhotoRates))
-    allocate (cnn(numPhotoRates), photoRateNames(numPhotoRates), transmissionFactor(numPhotoRates))
-  end subroutine allocate_photolysis_rates_variables
+    allocate (ck(numUnconstrainedPhotoRates), cl(numUnconstrainedPhotoRates), cmm(numUnconstrainedPhotoRates))
+    allocate (cnn(numUnconstrainedPhotoRates), unconstrainedPhotoNames(numUnconstrainedPhotoRates), &
+              transmissionFactor(numUnconstrainedPhotoRates))
+  end subroutine allocate_unconstrained_photolysis_rates_variables
 
   subroutine allocate_photolysis_j()
     implicit none

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -474,27 +474,35 @@ module photolysis_rates_mod
   implicit none
   save
 
-  integer(kind=NPI) :: numConPhotoRates
-  integer(kind=NPI), allocatable :: constrainedPhotoRatesNumbers(:)
+  integer(kind=NPI) :: numConstrainedPhotoRates
+  integer(kind=NPI), allocatable :: constrainedPhotoRatesNumbers(:), constantPhotoJNumbers(:)
   integer(kind=NPI) :: jFacSpeciesLine = 0_NPI ! number of line in photolysis rates file corresponding to Jfac species
-  integer(kind=NPI) :: numPhotoRates
-  integer(kind=NPI), allocatable :: ck(:)
-  logical :: usePhotolysisConstants
+  integer(kind=NPI) :: numPhotoRates, totalNumPhotos, numConstantPhotoRates
+  integer(kind=NPI), allocatable :: ck(:), photoNumbers(:)
+  logical :: usePhotolysisConstants, allPRsConstrained, usePhotolysisConstraints
   real(kind=DP), allocatable :: cl(:), cmm(:), cnn(:), transmissionFactor(:)
-  real(kind=DP), allocatable :: j(:)
-  character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:), constrainedPhotoRates(:)
+  real(kind=DP), allocatable :: j(:), constantPhotoValues(:)
+  character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:), constrainedPhotoNames(:), constantPhotoNames(:)
   character(len=maxPhotoRateNameLength) :: jFacSpecies
   real(kind=DP), allocatable :: photoX(:,:), photoY(:,:)
   integer(kind=NPI), allocatable :: photoNumberOfPoints(:)
   integer(kind=NPI) :: size_of_j
+  integer(kind=SI) :: PR_type
 
 contains
 
   subroutine allocate_photolysis_constants_variables()
     implicit none
 
-    allocate (ck(numPhotoRates), cl(numPhotoRates), photoRateNames(numPhotoRates))
+    allocate (constantPhotoJNumbers(numConstantPhotoRates), constantPhotoValues(numConstantPhotoRates), &
+              constantPhotoNames(numConstantPhotoRates))
   end subroutine allocate_photolysis_constants_variables
+
+  subroutine allocate_photolysis_numbers_variables()
+    implicit none
+
+    allocate (photoNumbers(totalNumPhotos))
+  end subroutine allocate_photolysis_numbers_variables
 
   subroutine allocate_photolysis_rates_variables()
     implicit none

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -479,7 +479,7 @@ module photolysis_rates_mod
   integer(kind=NPI) :: jFacSpeciesLine = 0_NPI ! number of line in photolysis rates file corresponding to Jfac species
   integer(kind=NPI) :: totalNumPhotos, numConstantPhotoRates
   integer(kind=NPI), allocatable :: ck(:), photoNumbers(:)
-  logical :: usePhotolysisConstants, usePhotolysisConstraints, unconstrainedPhotosExist
+  logical :: usePhotolysisConstants, usePhotolysisConstraints, unconstrainedPhotosExist, jFacSpeciesFound
   real(kind=DP), allocatable :: cl(:), cmm(:), cnn(:), transmissionFactor(:)
   real(kind=DP), allocatable :: j(:), constantPhotoValues(:)
   character(len=maxPhotoRateNameLength), allocatable :: photoRateNames(:), constrainedPhotoNames(:), constantPhotoNames(:), &
@@ -489,6 +489,7 @@ module photolysis_rates_mod
   integer(kind=NPI), allocatable :: photoNumberOfPoints(:)
   integer(kind=NPI) :: size_of_j
   integer(kind=SI) :: PR_type
+  real(kind=DP) :: jFacL, jFacM, jFacN, jFacTransmissionFactor
 
 contains
 

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -466,7 +466,6 @@ contains
     ! Strip first character (which will be 'J'), then convert to integer
     do i = 1, numConstrainedPhotoRates
       read(constrainedPhotoNames(i)(2:maxPhotoRateNameLength),*,iostat=ierr ) constrainedPhotoRatesNumbers(i)
-      write(*, '(A, I0)') constrainedPhotoNames(i), constrainedPhotoRatesNumbers(i)
     end do
 
     fileLocationPrefix = trim( env_constraints_dir ) // "/"
@@ -616,11 +615,9 @@ contains
       end if
       this_ck_pos = scan(line, "0123456789")
       read(line(this_ck_pos:),'(I4)') this_ck
-      write(*,*) 'this_ck:', this_ck
       ! If this line is associated to an unconstrained photo rate, then write the line to the appropriate variables
       if ( isInNPIArray( this_ck, unconstrainedPhotoNumbers ) .eqv. .true. ) then
         index = index + 1_NPI
-        write(*,*) line
         read (line,*, iostat=ierr) ck(index), cl(index), cmm(index), cnn(index), unconstrainedPhotoNames(index), &
                                    transmissionFactor(index)
       end if
@@ -632,15 +629,15 @@ contains
 
     if ( numUnconstrainedPhotoRates > 3 ) then
       write (*, '(I7, 1P e15.3, 1P e15.3, 1P e15.3, A, 1P e15.3)') &
-                                ck(1), cl(1), cmm(1), cnn(1), adjustr( photoRateNames(1) ), transmissionFactor(1)
+                                ck(1), cl(1), cmm(1), cnn(1), adjustr( unconstrainedPhotoNames(1) ), transmissionFactor(1)
       write (*, '(A)') ' ...'
       write (*, '(I7, 1P e15.3, 1P e15.3, 1P e15.3, A, 1P e15.3)') ck(numUnconstrainedPhotoRates), cl(numUnconstrainedPhotoRates), &
                   cmm(numUnconstrainedPhotoRates), cnn(numUnconstrainedPhotoRates), &
-                  adjustr( photoRateNames(numUnconstrainedPhotoRates) ), transmissionFactor(numUnconstrainedPhotoRates)
+                  adjustr( unconstrainedPhotoNames(numUnconstrainedPhotoRates) ), transmissionFactor(numUnconstrainedPhotoRates)
     else
       do i = 1, numUnconstrainedPhotoRates
         write (*, '(I7, 1P e15.3, 1P e15.3, 1P e15.3, A, 1P e15.3)') &
-                                ck(i), cl(i), cmm(i), cnn(i), adjustr( photoRateNames(i) ), transmissionFactor(i)
+                                ck(i), cl(i), cmm(i), cnn(i), adjustr( unconstrainedPhotoNames(i) ), transmissionFactor(i)
       end do
     end if
     write (*, '(A)') ' Finished reading unconstrained photolysis rates.'
@@ -657,7 +654,7 @@ contains
   subroutine readAllPhotolysisRates()
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
-    use photolysis_rates_mod, only : ck, cl, cmm, cnn, photoRateNames, &
+    use photolysis_rates_mod, only : ck, cl, cmm, cnn, unconstrainedPhotoNames, &
                                      transmissionFactor, allocate_unconstrained_photolysis_rates_variables, &
                                      allocate_photolysis_j, numConstrainedPhotoRates, numUnconstrainedPhotoRates
     use directories_mod, only : param_dir
@@ -681,7 +678,7 @@ contains
     open (10, file=filename, status='old')
     read (10,*) ! Ignore first line
     do i = 1, numUnconstrainedPhotoRates
-      read (10,*, iostat=ierr) ck(i), cl(i), cmm(i), cnn(i), photoRateNames(i), transmissionFactor(i)
+      read (10,*, iostat=ierr) ck(i), cl(i), cmm(i), cnn(i), unconstrainedPhotoNames(i), transmissionFactor(i)
       if ( ierr /= 0 ) then
         stop 'readAllPhotolysisRates(): error reading file'
       end if
@@ -690,15 +687,15 @@ contains
 
     if ( numUnconstrainedPhotoRates > 3 ) then
       write (*, '(I7, 1P e15.3, 1P e15.3, 1P e15.3, A, 1P e15.3)') &
-                                ck(1), cl(1), cmm(1), cnn(1), adjustr( photoRateNames(1) ), transmissionFactor(1)
+                                ck(1), cl(1), cmm(1), cnn(1), adjustr( unconstrainedPhotoNames(1) ), transmissionFactor(1)
       write (*, '(A)') ' ...'
       write (*, '(I7, 1P e15.3, 1P e15.3, 1P e15.3, A, 1P e15.3)') ck(numUnconstrainedPhotoRates), cl(numUnconstrainedPhotoRates), &
                   cmm(numUnconstrainedPhotoRates), cnn(numUnconstrainedPhotoRates), &
-                  adjustr( photoRateNames(numUnconstrainedPhotoRates) ), transmissionFactor(numUnconstrainedPhotoRates)
+                  adjustr( unconstrainedPhotoNames(numUnconstrainedPhotoRates) ), transmissionFactor(numUnconstrainedPhotoRates)
     else
       do i = 1, numUnconstrainedPhotoRates
         write (*, '(I7, 1P e15.3, 1P e15.3, 1P e15.3, A, 1P e15.3)') &
-                                ck(i), cl(i), cmm(i), cnn(i), adjustr( photoRateNames(i) ), transmissionFactor(i)
+                                ck(i), cl(i), cmm(i), cnn(i), adjustr( unconstrainedPhotoNames(i) ), transmissionFactor(i)
       end do
     end if
     write (*, '(A)') ' Finished reading all photolysis rates.'

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -865,7 +865,6 @@ contains
     integer(kind=IntErr) :: ierr
     !logical :: jFacSpeciesFound
 
-    write (*,*) 'start jfcp'
     ! Read the config file, counting the lines
     filename = trim( param_dir ) // '/photolysisRates.config'
     write (*, '(A)') ' Reading all photolysis rates from file...'
@@ -884,19 +883,14 @@ contains
       end if
   !     ! If this line is associated to an unconstrained photo rate, then write the line to the appropriate variables
        if ( trim( name ) == trim( jFacSpecies ) ) then
-         write (*,'(A)') 'found'
          jFacSpeciesFound = .true.
-         write (*,'(A)') 'assigned'
          exit
       end if
     end do
     close (11, status='keep')
-    write (*,'(A)') 'write value'
-    write (*,*) jFacSpeciesFound
     if ( jFacSpeciesFound .eqv. .false. ) then
        stop 'jFac base data for species ' // trim( jFacSpecies ) // ' not found in ' // trim( filename )
     end if
-    write (*,*) 'end jfcp'
     return
   end subroutine readJFacCalculationParameters
 
@@ -993,7 +987,6 @@ contains
             stop
           end if
         case ('TEMP', 'RH', 'H2O', 'PRESS', 'BLHEIGHT', 'DILUTE', 'DEC')
-          write(*,*) trim( envVarNames(i) ), trim( envVarTypes(i) )
           select case ( trim( envVarTypes(i) ) )
             case ('CALC')
               envVarTypesNum(i) = 1_SI

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -975,11 +975,11 @@ contains
               call readJFacCalculationParameters()
 
               ! If it's not a valid photolysis rate then treat as a fixed number
-               if ( jFacSpeciesFound .eqv. .false. ) then
-                 jFacSpecies = ''
-                 envVarTypesNum(i) = 3_SI
-                 read (envVarTypes(i),*) envVarFixedValues(i)
-               end if
+              if ( jFacSpeciesFound .eqv. .false. ) then
+                jFacSpecies = ''
+                envVarTypesNum(i) = 3_SI
+                read (envVarTypes(i),*) envVarFixedValues(i)
+              end if
           end select
         case ('ROOFOPEN')
           if ( trim( envVarTypes(i) ) == 'ON' ) then
@@ -997,20 +997,14 @@ contains
           select case ( trim( envVarTypes(i) ) )
             case ('CALC')
               envVarTypesNum(i) = 1_SI
-              write (*,*) 1
             case ('CONSTRAINED')
               envVarTypesNum(i) = 2_SI
-              write (*,*) 2
             case ('NOTUSED')
               envVarTypesNum(i) = 4_SI
-              write (*,*) 4
             case default
               envVarTypesNum(i) = 3_SI
-              write (*,*) 3
               ! Copy 3rd column value to envVarFixedValues(i)
-              write (*,*) 'read start'
               read (envVarTypes(i),*) envVarFixedValues(i)
-              write (*,*) 'read finished'
           end select
         case default
           write (stderr,*) 'readEnvVar(): Invalid environment variable ', trim( envVarNames(i) ), &

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -889,7 +889,7 @@ contains
     end do
     close (11, status='keep')
     if ( jFacSpeciesFound .eqv. .false. ) then
-       stop 'jFac base data for species ' // trim( jFacSpecies ) // ' not found in ' // trim( filename )
+       write (*,'(5A)') ' ', trim( jFacSpecies ), ' not found in ', trim( filename ), ', so it will be treated as a constant.'
     end if
     return
   end subroutine readJFacCalculationParameters

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -125,7 +125,8 @@ contains
     use types_mod
     use photolysis_rates_mod, only : ck, j, constantPhotoNames, numConstantPhotoRates, &
                                      constrainedPhotoNames, numConstrainedPhotoRates, &
-                                     unconstrainedPhotoNames, numUnconstrainedPhotoRates
+                                     unconstrainedPhotoNames, numUnconstrainedPhotoRates, PR_type, &
+                                     constrainedPhotoRatesNumbers
     implicit none
 
     real(kind=DP), intent(in) :: t
@@ -134,21 +135,30 @@ contains
 
     ! Output constant photolysis rates if any.
     ! Otherrwise, output constrained (if any), then unconstrained (if any).
-    if ( allocated(constantPhotoNames) .eqv. .true. ) then
+    if ( PR_type == 1 ) then
       if ( firstTime .eqv. .true. ) then
         write (58, '(100A15) ') 't', (trim( constantPhotoNames(i) ), i = 1, numConstantPhotoRates)
         firstTime = .false.
       end if
       write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numConstantPhotoRates)
     end if
-    if ( allocated(constrainedPhotoNames) .eqv. .true. ) then
+    if ( PR_type == 2 ) then
       if ( firstTime .eqv. .true. ) then
         write (58, '(100A15) ') 't', (trim( constrainedPhotoNames(i) ), i = 1, numConstrainedPhotoRates)
         firstTime = .false.
       end if
-      write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numConstrainedPhotoRates)
+      write (58, '(100 (ES15.6E3)) ') t, (j(constrainedPhotoRatesNumbers(i)), i = 1, numConstrainedPhotoRates)
     end if
-    if ( allocated(unconstrainedPhotoNames) .eqv. .true. ) then
+    if ( PR_type == 3) then
+      if ( firstTime .eqv. .true. ) then
+        write (58, '(100A15) ') 't', (trim( unconstrainedPhotoNames(i) ), i = 1, numUnconstrainedPhotoRates), &
+                                (trim( constrainedPhotoNames(i) ), i = 1, numConstrainedPhotoRates)
+        firstTime = .false.
+      end if
+      write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numUnconstrainedPhotoRates), &
+                                     (j(constrainedPhotoRatesNumbers(i)), i = 1, numConstrainedPhotoRates)
+    end if
+    if ( PR_type == 4 ) then
       if ( firstTime .eqv. .true. ) then
         write (58, '(100A15) ') 't', (trim( unconstrainedPhotoNames(i) ), i = 1, numUnconstrainedPhotoRates)
         firstTime = .false.

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -123,7 +123,7 @@ contains
   ! Write photolysis rates to file.
   subroutine outputPhotolysisRates( t )
     use types_mod
-    use photolysis_rates_mod, only : numPhotoRates, ck, j, photoRateNames
+    use photolysis_rates_mod, only : ck, j, photoRateNames, totalNumPhotos
     implicit none
 
     real(kind=DP), intent(in) :: t
@@ -131,10 +131,10 @@ contains
     logical :: firstTime = .true.
 
     if ( firstTime .eqv. .true. ) then
-      write (58, '(100A15) ') 't', (trim( photoRateNames(i) ), i = 1, numPhotoRates)
+      write (58, '(100A15) ') 't', (trim( photoRateNames(i) ), i = 1, totalNumPhotos)
       firstTime = .false.
     end if
-    write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numPhotoRates)
+    write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, totalNumPhotos)
 
     return
   end subroutine outputPhotolysisRates

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -123,19 +123,38 @@ contains
   ! Write photolysis rates to file.
   subroutine outputPhotolysisRates( t )
     use types_mod
-    use photolysis_rates_mod, only : ck, j, photoRateNames, totalNumPhotos
+    use photolysis_rates_mod, only : ck, j, constantPhotoNames, numConstantPhotoRates, &
+                                     constrainedPhotoNames, numConstrainedPhotoRates, &
+                                     unconstrainedPhotoNames, numUnconstrainedPhotoRates
     implicit none
 
     real(kind=DP), intent(in) :: t
     integer(kind=NPI) :: i
     logical :: firstTime = .true.
 
-    if ( firstTime .eqv. .true. ) then
-      write (58, '(100A15) ') 't', (trim( photoRateNames(i) ), i = 1, totalNumPhotos)
-      firstTime = .false.
+    ! Output constant photolysis rates if any.
+    ! Otherrwise, output constrained (if any), then unconstrained (if any).
+    if ( allocated(constantPhotoNames) .eqv. .true. ) then
+      if ( firstTime .eqv. .true. ) then
+        write (58, '(100A15) ') 't', (trim( constantPhotoNames(i) ), i = 1, numConstantPhotoRates)
+        firstTime = .false.
+      end if
+      write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numConstantPhotoRates)
     end if
-    write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, totalNumPhotos)
-
+    if ( allocated(constrainedPhotoNames) .eqv. .true. ) then
+      if ( firstTime .eqv. .true. ) then
+        write (58, '(100A15) ') 't', (trim( constrainedPhotoNames(i) ), i = 1, numConstrainedPhotoRates)
+        firstTime = .false.
+      end if
+      write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numConstrainedPhotoRates)
+    end if
+    if ( allocated(unconstrainedPhotoNames) .eqv. .true. ) then
+      if ( firstTime .eqv. .true. ) then
+        write (58, '(100A15) ') 't', (trim( unconstrainedPhotoNames(i) ), i = 1, numUnconstrainedPhotoRates)
+        firstTime = .false.
+      end if
+      write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1, numUnconstrainedPhotoRates)
+    end if
     return
   end subroutine outputPhotolysisRates
 

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -219,7 +219,7 @@ contains
       end if
     end do
 
-    do i = 1, numConPhotoRates
+    do i = 1, numConstrainedPhotoRates
       call getConstrainedQuantAtT( t, photoX, photoY, photoNumberOfPoints(i), &
                                    getConditionsInterpMethod(), i, photoRateAtT )
       j(constrainedPhotoRatesNumbers(i)) = photoRateAtT

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -206,7 +206,6 @@ contains
     end do
 
     call calcAtmosphere( m, o2, n2 )
-    write(*,*) numUnconstrainedPhotoRates, ck(1)
 
     do i = 1, numUnconstrainedPhotoRates
       if ( usePhotolysisConstants .eqv. .false. ) then

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -206,8 +206,9 @@ contains
     end do
 
     call calcAtmosphere( m, o2, n2 )
+    write(*,*) numUnconstrainedPhotoRates, ck(1)
 
-    do i = 1, numPhotoRates
+    do i = 1, numUnconstrainedPhotoRates
       if ( usePhotolysisConstants .eqv. .false. ) then
         if ( cosx_below_threshold .eqv. .true. ) then
           j(ck(i)) = 0.0_DP


### PR DESCRIPTION
While not quite production ready (there are a few bits I want to tweak), this now passes all current tests, except for the fact that it modifies the screen output of each test (because the execution order changes, so the reference screen output needs to be updated) and a small change to the way photolysis rates are output in `photolysisRates.output`. Rather than all photolysis rates being output in the order they come in `photolysisRates,config`, we have them ordered as firstly the unconstrained rates (those that are calculated) and then the constrained rates.

Is this acceptable @rs028? It would be a bit of a pain to reorder them.