### PR TITLE
Address non-generated D+08-style constants

### DIFF
--- a/src/atmosphereFunctions.f90
+++ b/src/atmosphereFunctions.f90
@@ -73,10 +73,10 @@ contains
 
     ! Calculate volume of water vapour per volume of dry air using
     ! Eq.18 (see Vaisala paper).
-    h2o_ppm = 1.0d+06 * wvp / (press - wvp)
+    h2o_ppm = 1.0e+06_DP * wvp / (press - wvp)
 
     ! convert ppm to molecule cm-3
-    h2o = h2o_ppm * calcAirDensity(press, temp) * 1.0d-06
+    h2o = h2o_ppm * calcAirDensity(press, temp) * 1.0e-06_DP
 
     return
   end function convertRHtoH2O
@@ -90,10 +90,10 @@ contains
 
     real(kind=DP) :: temp, ttime, rh, h2o, sin, h2o_factor, exponent
 
-    temp = 289.86_DP + 8.3_DP * sin( ( 7.2722d-5 * ttime ) - 1.9635_DP )
+    temp = 289.86_DP + 8.3_DP * sin( ( 7.2722e-5_DP * ttime ) - 1.9635_DP )
     temp = 298.00_DP
-    rh = 23.0_DP * sin( ( 7.2722d-5 * ttime ) + 1.1781_DP ) + 66.5_DP
-    h2o_factor = 10.0_DP / ( 1.38d-16 * temp ) * rh
+    rh = 23.0_DP * sin( ( 7.2722e-5_DP * ttime ) + 1.1781_DP ) + 66.5_DP
+    h2o_factor = 10.0_DP / ( 1.38e-16_DP * temp ) * rh
     exponent = -1.0_DP * ( 597.3_DP - 0.57_DP * ( temp - 273.16_DP ) ) * 18.0_DP / 1.986_DP * ( 1.0_DP / temp - 1.0_DP / 273.16_DP )
     h2o = 6.1078_DP * exp( exponent ) * h2o_factor
 

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -312,7 +312,7 @@ contains
               this_env_val = 298.15_DP
               temp_set = .true.
             case ( 'H2O' )
-              this_env_val = 3.91d+17
+              this_env_val = 3.91e+17_DP
             case ( 'PRESS' )
               this_env_val = 1013.25_DP
             case ( 'BLHEIGHT', 'RH', 'DILUTE' )

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -549,7 +549,7 @@ module zenith_data_mod
   real(kind=DP) :: latitude, longitude
   real(kind=DP) :: lha, sinld, cosld, cosx, secx
   real(kind=DP) :: theta, eqtime
-  real(kind=DP), parameter :: cosx_threshold = 1.0d-30
+  real(kind=DP), parameter :: cosx_threshold = 1.0e-30_DP
   ! cosx_below_threshold contains whether or not cosx is currently
   ! below cosx_threshold
   logical :: cosx_below_threshold = .false.

--- a/src/solarFunctions.f90
+++ b/src/solarFunctions.f90
@@ -128,7 +128,7 @@ contains
     ! requires cosx and secx to calculate the photolysis rates.
     if ( cosx <= cosx_threshold ) then
       cosx = 0.0_DP
-      secx = 1.0d+50
+      secx = 1.0e+50_DP
       cosx_below_threshold = .true.
     else
       secx = 1.0_DP / cosx

--- a/tools/mech_converter.py
+++ b/tools/mech_converter.py
@@ -218,7 +218,7 @@ def convert(input_file, output_dir, mc_dir, mcm_dir):
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00\n""")
+ro2 = 0.00e+00_DP\n""")
 
             for ro2List_i in ro2List:
                 for speciesNumber, y in zip(range(1, len(speciesList) + 1), speciesList):

--- a/travis/tests/full/ro2-rates.f90.cmp
+++ b/travis/tests/full/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(29)!HO1C3O2
 ro2 = ro2 + y(30)!HYPROPO2

--- a/travis/tests/short/ro2-rates.f90.cmp
+++ b/travis/tests/short/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_dense/ro2-rates.f90.cmp
+++ b/travis/tests/short_dense/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_end_of_day/ro2-rates.f90.cmp
+++ b/travis/tests/short_end_of_day/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_ext1/ro2-rates.f90.cmp
+++ b/travis/tests/short_ext1/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_ext2/ro2-rates.f90.cmp
+++ b/travis/tests/short_ext2/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_ext3/ro2-rates.f90.cmp
+++ b/travis/tests/short_ext3/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_ext4/ro2-rates.f90.cmp
+++ b/travis/tests/short_ext4/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/short_no_pre/ro2-rates.f90.cmp
+++ b/travis/tests/short_no_pre/ro2-rates.f90.cmp
@@ -3,7 +3,7 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(26)!HOCH2CH2O2
 ro2 = ro2 + y(28)!BUT2OLO2
 ro2 = ro2 + y(30)!CH3O2

--- a/travis/tests/spec_no_env_yes1/ro2-rates.f90.cmp
+++ b/travis/tests/spec_no_env_yes1/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_no_env_yes2/ro2-rates.f90.cmp
+++ b/travis/tests/spec_no_env_yes2/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_env_no/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_env_no/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_env_no_with_jfac/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_env_no_with_jfac_fail1/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac_fail1/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_env_no_with_jfac_fixed/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac_fixed/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_env_no_with_photo/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_env_no_with_photo/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_env_yes/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_env_yes/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2

--- a/travis/tests/spec_yes_plus_fixed_env_no/ro2-rates.f90.cmp
+++ b/travis/tests/spec_yes_plus_fixed_env_no/ro2-rates.f90.cmp
@@ -3,5 +3,5 @@
 ! Any manual edits to this file will be overwritten when
 ! calling tools/mech_converter.py
 
-ro2 = 0.00D+00
+ro2 = 0.00e+00_DP
 ro2 = ro2 + y(23)!CH3O2


### PR DESCRIPTION
Change remaining non-generated constants to use e+08_DP instead of D+08 form. Also change generated line for ro2.

Addresses #299, but not completely - need to look into whether the generated files should use this form too.