### PR TITLE
Further unit tests for atmosphere functions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,4 +5,6 @@ coverage:
         threshold: 5%
       tests:  # declare a new status context "tests"
         target: 100%  # we always want 100% coverage here
-        paths: "travis/tests/"  # only include coverage in "travis/tests/" folder
+        paths:
+          - travis/tests/  # only include coverage in "travis/tests/" and "travis/unit_tests" folders
+          - travis/unit_tests/

--- a/src/atmosphereFunctions.f90
+++ b/src/atmosphereFunctions.f90
@@ -63,7 +63,7 @@ contains
     implicit none
 
     real(kind=DP), intent(in) :: rh, temp, press
-    real(kind=DP) :: h2o, h2o_ppm, temp_c, wvp
+    real(kind=DP) :: h2o, h2o_ppu, temp_c, wvp
 
     ! Use Eq.6 to calculate the water vapour saturation pressure and
     ! Eq.1 to calculate the water vapour pressure from relative
@@ -72,11 +72,14 @@ contains
     wvp = ( rh/100.0_DP ) * ( 6.116441_DP * 10.0_DP**((7.591386_DP * temp_c)/(temp_c + 240.7263_DP)) )
 
     ! Calculate volume of water vapour per volume of dry air using
-    ! Eq.18 (see Vaisala paper).
-    h2o_ppm = 1.0e+06_DP * wvp / (press - wvp)
+    ! Eq.18 (see Vaisala paper). We don't use ppm here, because doing
+    ! so requires a multiplication by 1e6 then division by the same
+    ! in the final line. This incurs possible rounding. Instead, we
+    ! use 'parts per unit'
+    h2o_ppu = wvp / (press - wvp)
 
-    ! convert ppm to molecule cm-3
-    h2o = h2o_ppm * calcAirDensity(press, temp) * 1.0e-06_DP
+    ! convert ppv to molecule cm-3
+    h2o = h2o_ppu * calcAirDensity(press, temp)
 
     return
   end function convertRHtoH2O

--- a/travis/unit_tests/atmosphere_test.f90
+++ b/travis/unit_tests/atmosphere_test.f90
@@ -45,7 +45,51 @@ contains
     call assert_true( m == 2.0_DP, "m unchanged 2" )
     call assert_true( o2 == 0.4190_DP, "o2 correct 2" )
     call assert_true( n2 == 1.5618_DP, "n2 correct 2" )
+
+    m = 0.0_DP
+    call calcAtmosphere( m, o2, n2 )
+
+    call assert_true( m == 0.0_DP, "m unchanged 0" )
+    call assert_true( o2 == 0.0_DP, "o2 correct 0" )
+    call assert_true( n2 == 0.0_DP, "n2 correct 0" )
   end subroutine test_calcAtmosphere
+
+  subroutine test_convertRHtoH2O
+    use types_mod
+    use atmosphere_functions_mod
+    implicit none
+
+    real(kind=DP) :: rh, temp, press, ad, h2o
+
+    rh = 50.0_DP
+    temp = 273.15_DP
+    press = 6.116441_DP
+
+    ad = calcAirDensity(press, temp)
+
+    h2o = convertRHtoH2O( rh, temp, press )
+
+    call assert_equals( h2o, ad, "convertRHtoH2O: 50% relative humidity, 0C, pressure = A" )
+
+    rh = 100.0_DP
+    temp = 273.15_DP
+    press = 2.0_DP*6.116441_DP
+
+    ad = calcAirDensity(press, temp)
+
+    h2o = convertRHtoH2O( rh, temp, press )
+
+    call assert_equals( h2o, ad, "convertRHtoH2O: 100% relative humidity, 0C, pressure = 2*A" )
+
+    rh = 0.0_DP
+    temp = 300.0_DP
+    press = 10.0_DP
+
+    h2o = convertRHtoH2O( rh, temp, press )
+
+    call assert_equals( h2o, 0.0_DP, "convertRHtoH2O: 0% relative humidity" )
+
+  end subroutine test_convertRHtoH2O
 
   subroutine test_zero_equal
     use types_mod


### PR DESCRIPTION
Add tests for convertRHtoH2O(), and use parts-per-unit rather than parts-per-million to reduce numerical effects. Add another test for calcAtmosphere().