### PR TITLE
Use caching of gfortran on Travis + MacOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,16 @@
 
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; brew update ; brew install gcc@4.9 libffi gettext ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_numdiff.sh $PWD ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; PATH=$PATH:$PWD/numdiff/bin ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./tools/install/install_numdiff_macOS.sh $PWD ; export PATH=$PATH:$PWD/numdiff/bin ; fi
     - ./tools/install/install_fruit.sh $PWD
 
   install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9 ; fi
     - cd $TRAVIS_BUILD_DIR
     - cp tools/Makefile Makefile
     - ./tools/build.sh ./tools/mcm_example.fac
@@ -40,7 +41,7 @@
   script:
     - ./atchem2
     - make unittests
-    - make test
+    - make behaviourtests
 
   after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@
   compiler:
     - gcc
 
+  cache:
+    directories: /usr/local/Cellar/gcc@4.9/4.9.4_1
+
   addons:
     apt:
       packages:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -28,13 +28,16 @@ ifeq ($(TRAVIS),true)
 ifeq ($(TRAVIS_OS_NAME),linux)
 # if linux, pass gfortran
 FORT_COMP    = gfortran
+FORT_LIB = ""
 else
 # if macOS, pass homebrew gfortran
 FORT_COMP    = /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9
+FORT_LIB     = /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9
 endif
 # else it's not on Travis, so set the fortran compiler as gfortran
 else
 FORT_COMP    = gfortran
+FORT_LIB = ""
 endif
 
 ifeq ($(OS),Linux)
@@ -83,7 +86,7 @@ $(fruit_driver) : $(all_unittest_code)
 	$(FORT_COMP) -o $(fruit_driver) -J$(OBJ) -I$(OBJ) $(all_unittest_code) $(FFLAGS) $(LDFLAGS)
 
 unittests: $(fruit_driver)
-	@export DYLD_LIBRARY_PATH=$(CVODELIB):$(OPENLIBMDIR) ; $(fruit_driver)
+	@export DYLD_LIBRARY_PATH=$(FORT_LIB):$(CVODELIB):$(OPENLIBMDIR) ; $(fruit_driver)
 
 # search travis/tests/ for all subdirectories, which should reflect the full list of tests
 TESTS := $(shell ls -d travis/tests/*/ | sed 's,travis/tests/,,g' | sed 's,/,,g')
@@ -93,7 +96,7 @@ behaviourtests:
 	@make clean
 	@echo "Make: Running the following tests:" $(TESTS)
 	@rm -f travis/tests/results
-	@./travis/run_tests.sh "$(TESTS)" "$(CVODELIB):$(OPENLIBMDIR)"
+	@./travis/run_tests.sh "$(TESTS)" "$(FORT_LIB):$(CVODELIB):$(OPENLIBMDIR)"
 
 test : unittests behaviourtests
 


### PR DESCRIPTION
This should save about 2 minutes on the Mac Travis build, which would. be useful!

As SIP blocks the export of DYLD_LIBRARY_PATH to scripts, we use a new FORT_LIB variable in the Makefile to pass on the locations to use. Also make sure PATH is exported, not just set on .travis.yml, and run make behaviourtests after make unittests, rather than make test.