### PR TITLE
Split first column from prod/reacDetailedRatesSpecies

### DIFF
--- a/src/configFunctions.f90
+++ b/src/configFunctions.f90
@@ -83,12 +83,12 @@ contains
   ! Fill the second (and later) column(s) of each row of r with the
   ! numbers of the reactions in which it is present in chs. Used
   ! arrayLen to keep track of how many are present in each row.
-  subroutine findReactionsWithProductOrReactant( r, chs, arrayLen )
+  subroutine findReactionsWithProductOrReactant( rSpecies, r, chs, arrayLen )
     use types_mod
     implicit none
 
     integer(kind=NPI), intent(inout) :: r(:,:)
-    integer(kind=NPI), intent(in) :: chs(:,:)
+    integer(kind=NPI), intent(in) :: rSpecies(:), chs(:,:)
     integer(kind=NPI), intent(out) :: arrayLen(:)
     integer(kind=NPI) :: rCounter, i, j
 
@@ -101,7 +101,7 @@ contains
       stop "size(arrayLen) /= size(r, 1) in findReactionsWithProductOrReactant()."
     end if
     ! initialise counter for r array
-    rCounter = 2
+    rCounter = 1
     ! loop over interesting species (i.e. over 1st index of r)
     do i = 1, size( arrayLen )
       ! loop over elements of 2nd index of chs
@@ -111,14 +111,14 @@ contains
         ! interesting species number)?  If so, then append the first
         ! element of this row in chs (the equation number) to this row
         ! in r, and update the length counter arrayLen for this row.
-        if ( chs(2, j) == r(i, 1) ) then
+        if ( chs(2, j) == rSpecies(i) ) then
           ! Match found
           r(i, rCounter) = chs(1, j)
           rCounter = rCounter + 1
         end if
       end do
-      arrayLen(i) = rCounter - 1
-      rCounter = 2
+      arrayLen(i) = rCounter
+      rCounter = 1
     end do
 
     return

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -240,14 +240,14 @@ contains
 
   ! ----------------------------------------------------------------- !
   ! Write production and loss rates to file.
-  subroutine outputRates( r, arrayLen, t, p, flag )
+  subroutine outputRates( rSpecies, r, arrayLen, t, p, flag )
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
     use species_mod, only : getSpeciesList
     use storage_mod, only : maxSpecLength, maxReactionStringLength
     implicit none
 
-    integer(kind=NPI), intent(in) :: r(:,:), arrayLen(:)
+    integer(kind=NPI), intent(in) :: r(:,:), arrayLen(:), rSpecies(:)
     real(kind=DP), intent(in) :: t, p(:)
     integer(kind=SI), intent(in) :: flag
     character(len=maxSpecLength), allocatable :: speciesNames(:)
@@ -283,10 +283,12 @@ contains
         write (stderr,*) "arrayLen(i) > size( r, 2 ) in outputRates(). i = ", i
         stop
       end if
-      do j = 2, arrayLen(i)
+
+      do j = 1, arrayLen(i)
         if ( r(i, j) /= -1 ) then
           reaction = getReaction( speciesNames, r(i, j) )
-          write (output_file_number, '(ES15.6E3, I14, A12, I15, ES15.6E3, A, A)') t, r(i, 1), trim( speciesNames(r(i, 1)) ), &
+          write (output_file_number, '(ES15.6E3, I14, A12, I15, ES15.6E3, A, A)') t, rSpecies(i), &
+                                                                                  trim( speciesNames(rSpecies(i)) ), &
                                                                                   r(i, j), p(r(i, j)), '  ', trim( reaction )
         end if
       end do


### PR DESCRIPTION
Move the first column from `prod/reacDetailedRatesSpecies` to `detailedRatesSpecies`. This means `prod/reacDetailedRatesSpecies` just contain the numbers of equations containing the given species, rather than also including the number of the species.