### PR TITLE
Catch build errors in run_tests.sh

### DIFF
--- a/travis/run_tests.sh
+++ b/travis/run_tests.sh
@@ -145,7 +145,11 @@ for test in $1; do
   test_counter=$((test_counter+1))
   echo "set up and make" $TESTS_DIR/$test
   ./tools/build.sh $TESTS_DIR/$test/model/configuration/$test.fac src/gen $TESTS_DIR/$test/model/configuration $TESTS_DIR/$test/mcm &> /dev/null
-
+  exitcode=$?
+  if [ $exitcode -ne 0 ]; then
+    echo Building $test test failed with exit code $exitcode
+    exit $exitcode
+  fi
   # Run atchem2 with the argument pointing to the output directory
   echo Running   $TESTS_DIR/$test ...
   ./atchem2 $TESTS_DIR/$test/output $TESTS_DIR/$test/output/instantaneousRates $TESTS_DIR/$test/model/configuration $TESTS_DIR/$test/mcm $TESTS_DIR/$test/model/constraints/species $TESTS_DIR/$test/model/constraints/environment $TESTS_DIR/$test/model/constraints/photolysis > $TESTS_DIR/$test/$test.out


### PR DESCRIPTION
Catch error from make in tools/build.sh inside tools/run_tests.sh, and exit immediately. This stops local testing from accidentally using an old executable if the build fails, with hard-to-understand results.