### PR TITLE
Solar tests

### DIFF
--- a/src/solarFunctions.f90
+++ b/src/solarFunctions.f90
@@ -51,17 +51,13 @@ contains
   ! Calculate the sun declination (radians). Equations taken from "The
   ! Atmosphere and UV-B Radiation at Ground Level" by S. Madronich
   ! (Environmental UV Photobiology, 1993).
-  pure function calcDec() result ( dec )
+  pure function decFromTheta( theta ) result ( dec )
     use types_mod
     implicit none
 
-    real(kind=DP) :: theta, dec
-    real(kind=DP) :: b0, b1, b2, b3, b4, b5, b6
+    real(kind=DP), intent(in) :: theta
+    real(kind=DP) :: b0, b1, b2, b3, b4, b5, b6, dec
 
-    theta = calcTheta()
-
-    ! The sun declination is the angle between the center of the Sun
-    ! and Earth's equatorial plane.
     b0 =  0.006918_DP
     b1 = -0.399912_DP
     b2 =  0.070257_DP
@@ -69,8 +65,27 @@ contains
     b4 =  0.000907_DP
     b5 = -0.002697_DP
     b6 =  0.001480_DP
+    
     dec = b0 + b1 * cos(theta) + b2 * sin(theta) + b3 * cos(2.0_DP * theta) + &
           b4 * sin(2.0_DP * theta) + b5 * cos(3.0_DP * theta) + b6 * sin(3.0_DP * theta)
+
+    return
+  end function decFromTheta
+
+  ! -----------------------------------------------------------------
+  ! Calculate the sun declination (radians). Firstly update theta
+  ! (day angle) to today's value, then calculate dec from that.
+  pure function calcDec() result ( dec )
+    use types_mod
+    implicit none
+
+    real(kind=DP) :: theta, dec
+
+    theta = calcTheta()
+
+    ! The sun declination is the angle between the center of the Sun
+    ! and Earth's equatorial plane.
+    dec = decFromTheta( theta )
 
     return
   end function calcDec

--- a/travis/unit_tests/solar_test.f90
+++ b/travis/unit_tests/solar_test.f90
@@ -1,0 +1,44 @@
+module solar_test
+  use fruit
+  use types_mod
+  implicit none
+
+contains
+
+  subroutine test_calcDec
+    use types_mod
+    use solar_functions_mod
+    use zenith_data_mod, only : theta
+    implicit none
+
+    real(kind=DP) :: dec, pi
+
+    pi = 4.0_DP * atan( 1.0_DP )
+
+    theta = 0.0_DP
+    dec = calcDec()
+
+    call assert_true( dec == -0.402449_DP, "calcDec(), theta = 0" )
+    write(*,*) dec
+
+    theta = pi
+    dec = calcDec()
+
+    call assert_true( dec == 0.40276899999999999_DP, "calcDec(), theta = pi" )
+    write(*,*) dec
+
+    theta = pi/2.0_DP
+    dec = calcDec()
+
+    call assert_true( dec == 8.2452999999999985E-002_DP, "calcDec(), theta = pi/2" )
+    write(*,*) dec
+
+    theta = pi*3.0_DP/2.0_DP
+    dec = calcDec()
+
+    call assert_true( dec == -5.5100999999999921E-002_DP, "calcDec(), theta = 3pi/2" )
+    write(*,*) dec
+
+  end subroutine test_calcDec
+
+end module solar_test

--- a/travis/unit_tests/solar_test.f90
+++ b/travis/unit_tests/solar_test.f90
@@ -1,44 +1,109 @@
 module solar_test
   use fruit
   use types_mod
+  use solar_functions_mod
   implicit none
 
 contains
 
-  subroutine test_calcDec
-    use types_mod
-    use solar_functions_mod
-    use zenith_data_mod, only : theta
+  subroutine test_calcTheta
+    use date_mod, only : currentYear, currentDayOfYear
+    implicit none
+    real(kind=DP) :: theta, pi, threshold
+
+    threshold = 1.0e-8_DP
+    pi = 4.0_DP * atan( 1.0_DP )
+
+    currentYear = 2000_DI
+    currentDayOfYear = 0_DI
+    theta = calcTheta()
+    call assert_true( theta == 0.0_DP, "calcTheta(), first day of 2000" )
+
+    currentYear = 2000_DI
+    currentDayOfYear = 366_DI
+    theta = calcTheta()
+    call assert_true( theta == 2.0_DP*pi, "calcTheta(), last day of 2000" )
+
+    currentYear = 2001_DI
+    currentDayOfYear = 0_DI
+    theta = calcTheta()
+    call assert_true( theta == 0.0_DP, "calcTheta(), first day of 2001" )
+
+    currentYear = 2001_DI
+    currentDayOfYear = 365_DI
+    theta = calcTheta()
+    call assert_true( abs(theta - 2.0_DP*pi) <= threshold, "calcTheta(), last day of 2001" )
+
+    currentYear = 2004_DI
+    currentDayOfYear = 0_DI
+    theta = calcTheta()
+    call assert_true( theta == 0.0_DP, "calcTheta(), first day of 2004" )
+
+    currentYear = 2004_DI
+    currentDayOfYear = 366_DI
+    theta = calcTheta()
+    call assert_true( theta == 2.0_DP*pi, "calcTheta(), last day of 2004" )
+  end subroutine test_calcTheta
+
+  subroutine test_decFromTheta
     implicit none
 
-    real(kind=DP) :: dec, pi
+    real(kind=DP) :: dec, pi, theta
 
     pi = 4.0_DP * atan( 1.0_DP )
 
     theta = 0.0_DP
-    dec = calcDec()
-
-    call assert_true( dec == -0.402449_DP, "calcDec(), theta = 0" )
-    write(*,*) dec
+    dec = decFromTheta( theta )
+    call assert_true( dec == -0.402449_DP, "decFromTheta( theta ), theta = 0" )
 
     theta = pi
-    dec = calcDec()
-
-    call assert_true( dec == 0.40276899999999999_DP, "calcDec(), theta = pi" )
-    write(*,*) dec
+    dec = decFromTheta( theta )
+    call assert_true( dec == 0.40276899999999999_DP, "decFromTheta( theta ), theta = pi" )
 
     theta = pi/2.0_DP
-    dec = calcDec()
-
-    call assert_true( dec == 8.2452999999999985E-002_DP, "calcDec(), theta = pi/2" )
-    write(*,*) dec
+    dec = decFromTheta( theta )
+    call assert_true( dec == 8.2452999999999985E-002_DP, "decFromTheta( theta ), theta = pi/2" )
 
     theta = pi*3.0_DP/2.0_DP
-    dec = calcDec()
+    dec = decFromTheta( theta )
+    call assert_true( dec == -5.5100999999999921E-002_DP, "decFromTheta( theta ), theta = 3pi/2" )
 
-    call assert_true( dec == -5.5100999999999921E-002_DP, "calcDec(), theta = 3pi/2" )
-    write(*,*) dec
+  end subroutine test_decFromTheta
+
+  subroutine test_calcDec
+    use types_mod
+    use date_mod, only : currentYear, currentDayOfYear
+    implicit none
+    currentYear = 2000_DI
+    currentDayOfYear = 0_DI
+    call assert_true( calcDec() == 0, "calcDec(), first day of 2000" )
+
+    currentYear = 2000_DI
+    currentDayOfYear = 366_DI
+    call assert_true( calcDec() == 0, "calcDec(), last day of 2000" )
+
+    currentYear = 2001_DI
+    currentDayOfYear = 0_DI
+    call assert_true( calcDec() == 0, "calcDec(), first day of 2001" )
+
+    currentYear = 2001_DI
+    currentDayOfYear = 365_DI
+    call assert_true( calcDec() == 0, "calcDec(), last day of 2001" )
+
+    currentYear = 2004_DI
+    currentDayOfYear = 0_DI
+    call assert_true( calcDec() == 0, "calcDec(), first day of 2004" )
+
+    currentYear = 2004_DI
+    currentDayOfYear = 366_DI
+    call assert_true( calcDec() == 0, "calcDec(), last day of 2004" )
+
 
   end subroutine test_calcDec
+
+  subroutine test_calcZenith
+    implicit none
+
+  end subroutine test_calcZenith
 
 end module solar_test

--- a/travis/unit_tests/solar_test.f90
+++ b/travis/unit_tests/solar_test.f90
@@ -9,6 +9,7 @@ contains
   subroutine test_calcTheta
     use date_mod, only : currentYear, currentDayOfYear
     implicit none
+
     real(kind=DP) :: theta, pi, threshold
 
     threshold = 1.0e-8_DP
@@ -18,31 +19,26 @@ contains
     currentDayOfYear = 0_DI
     theta = calcTheta()
     call assert_true( theta == 0.0_DP, "calcTheta(), first day of 2000" )
-
-    currentYear = 2000_DI
-    currentDayOfYear = 366_DI
+    currentDayOfYear = 365_DI
     theta = calcTheta()
-    call assert_true( theta == 2.0_DP*pi, "calcTheta(), last day of 2000" )
+    call assert_true( theta == 2.0_DP*pi*365_DI/366_DI, "calcTheta(), last day of 2000" )
 
     currentYear = 2001_DI
     currentDayOfYear = 0_DI
     theta = calcTheta()
     call assert_true( theta == 0.0_DP, "calcTheta(), first day of 2001" )
-
-    currentYear = 2001_DI
-    currentDayOfYear = 365_DI
+    currentDayOfYear = 364_DI
     theta = calcTheta()
-    call assert_true( abs(theta - 2.0_DP*pi) <= threshold, "calcTheta(), last day of 2001" )
+    call assert_true( abs(theta - 2.0_DP*pi*364_DI/365_DI) <= threshold, "calcTheta(), last day of 2001" )
 
     currentYear = 2004_DI
     currentDayOfYear = 0_DI
     theta = calcTheta()
     call assert_true( theta == 0.0_DP, "calcTheta(), first day of 2004" )
-
-    currentYear = 2004_DI
-    currentDayOfYear = 366_DI
+    currentDayOfYear = 365_DI
     theta = calcTheta()
-    call assert_true( theta == 2.0_DP*pi, "calcTheta(), last day of 2004" )
+    call assert_true( theta == 2.0_DP*pi*365_DI/366_DI, "calcTheta(), last day of 2004" )
+
   end subroutine test_calcTheta
 
   subroutine test_decFromTheta
@@ -74,36 +70,64 @@ contains
     use types_mod
     use date_mod, only : currentYear, currentDayOfYear
     implicit none
-    currentYear = 2000_DI
-    currentDayOfYear = 0_DI
-    call assert_true( calcDec() == 0, "calcDec(), first day of 2000" )
+
+    real(kind=DP) :: dec0, dec364over365, dec365over366, threshold
+
+    threshold = 1.0e-6_DP
+    dec0 = 0.006918_DP - 0.399912_DP - 0.006758_DP - 0.002697_DP
+    dec364over365 = -0.40369912461219781
+    dec365over366 = -0.40369589165596537
 
     currentYear = 2000_DI
-    currentDayOfYear = 366_DI
-    call assert_true( calcDec() == 0, "calcDec(), last day of 2000" )
-
-    currentYear = 2001_DI
     currentDayOfYear = 0_DI
-    call assert_true( calcDec() == 0, "calcDec(), first day of 2001" )
-
-    currentYear = 2001_DI
+    call assert_true( calcDec() == dec0, "calcDec(), first day of 2000" )
     currentDayOfYear = 365_DI
-    call assert_true( calcDec() == 0, "calcDec(), last day of 2001" )
+    call assert_true( abs( calcDec() - dec365over366 ) < threshold, "calcDec(), last day of 2000" )
+
+    currentYear = 2001_DI
+    currentDayOfYear = 0_DI
+    call assert_true( calcDec() == dec0, "calcDec(), first day of 2001" )
+    currentDayOfYear = 364_DI
+    call assert_true( abs( calcDec() - dec364over365 ) < threshold, "calcDec(), last day of 2001" )
 
     currentYear = 2004_DI
     currentDayOfYear = 0_DI
-    call assert_true( calcDec() == 0, "calcDec(), first day of 2004" )
-
-    currentYear = 2004_DI
-    currentDayOfYear = 366_DI
-    call assert_true( calcDec() == 0, "calcDec(), last day of 2004" )
-
+    call assert_true( calcDec() == dec0, "calcDec(), first day of 2004" )
+    currentDayOfYear = 365_DI
+    call assert_true( abs( calcDec() - dec365over366 ) < threshold, "calcDec(), last day of 2004" )
 
   end subroutine test_calcDec
 
-  subroutine test_calcZenith
+  subroutine test_calcEQT
+    use types_mod
+    use date_mod, only : currentYear, currentDayOfYear
     implicit none
 
-  end subroutine test_calcZenith
+    real(kind=DP) :: eqt0, threshold
+
+    threshold = 1.0e-8_DP
+    eqt0 = 0.000075_DP + 0.001868_DP - 0.014615_DP
+
+    currentYear = 2000_DI
+    currentDayOfYear = 0_DI
+    call assert_true( abs( calcEQT() - eqt0 ) < threshold, "calcEQT(), first day of 2000" )
+    currentDayOfYear = 365_DI
+    call assert_true( abs( calcEQT() + 1.0710769160677822E-002 ) < threshold, "calcEQT(), last day of 2000" )
+
+    currentYear = 2001_DI
+    currentDayOfYear = 0_DI
+    call assert_true( abs( calcEQT() - eqt0 ) < threshold, "calcEQT(), first day of 2001" )
+    currentDayOfYear = 364_DI
+    call assert_true( abs( calcEQT() + 1.0705374687579837E-002 ) < threshold, "calcEQT(), last day of 2001" )
+
+    currentYear = 2004_DI
+    currentDayOfYear = 0_DI
+    call assert_true( abs( calcEQT() - eqt0 ) < threshold, "calcEQT(), first day of 2004" )
+    currentDayOfYear = 365_DI
+    call assert_true( abs( calcEQT() + 1.0710769160677822E-002 ) < threshold, "calcEQT(), last day of 2004" )
+
+  end subroutine test_calcEQT
+
+  ! TODO:  subroutine test_calcZenith
 
 end module solar_test


### PR DESCRIPTION
This contains unit tests for all the functions in `solarFunctions.f90` bar `calcZenith()`. I think that function wants refactoring, so I've left that as a TODO. `calcDec()` now has a helper function `decFromTheta()` which takes out some of the guts, and makes unit testing simpler.