### PR TITLE
Call getConcForSpeciesOfInterest() directly from outputSpeciesOfInterest()

### DIFF
--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -170,7 +170,7 @@ PROGRAM ATCHEM2
   ! Read in product species of interest, and set up variables to hold
   ! these
   write (*, '(A)') ' Reading which species require detailed rate output...'
-  call readProductsOrReactantsOfInterest( trim( param_dir ) // '/outputRates.config', detailedRatesSpeciesName )
+  call readDetailedRatesSpeciesNames( trim( param_dir ) // '/outputRates.config', detailedRatesSpeciesName )
   write (*, '(A)') ' Finished reading which species require detailed rate output.'
 
   allocate (detailedRatesSpecies(size( detailedRatesSpeciesName )))

--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -167,8 +167,8 @@ PROGRAM ATCHEM2
   write (*, '(A)') ' Species requiring detailed rate output'
   write (*, '(A)') '----------------------------------------'
 
-  ! Read in product species of interest, and set up variables to hold
-  ! these
+  ! Read in species requiring detailed reats output, and set up variables to
+  ! hold these
   write (*, '(A)') ' Reading which species require detailed rate output...'
   call readDetailedRatesSpeciesNames( trim( param_dir ) // '/outputRates.config', detailedRatesSpeciesName )
   write (*, '(A)') ' Finished reading which species require detailed rate output.'

--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -64,7 +64,6 @@ PROGRAM ATCHEM2
   integer(kind=NPI), allocatable :: detailedRatesSpecies(:)
   character(len=maxSpecLength), allocatable :: detailedRatesSpeciesName(:)
   ! Declarations for concentration outputs
-  real(kind=DP), allocatable :: concsOfSpeciesOfInterest(:)
   character(len=maxSpecLength), allocatable :: speciesOfInterest(:)
   ! simulation output time variables
   integer(kind=QI) :: time, elapsed
@@ -247,9 +246,6 @@ PROGRAM ATCHEM2
   speciesOfInterest = readSpeciesOfInterest()
   write (*,*)
 
-  ! Allocate concsOfSpeciesOfInterest
-  allocate ( concsOfSpeciesOfInterest(size( speciesOfInterest )))
-
   flush(stderr)
 
   ! *****************************************************************
@@ -280,8 +276,7 @@ PROGRAM ATCHEM2
   call readSpeciesConstraints( t, speciesConcs )
   write (*,*)
 
-  concsOfSpeciesOfInterest = getConcForSpeciesOfInterest( speciesConcs, speciesOfInterest )
-  call outputSpeciesOfInterest( t, speciesOfInterest, concsOfSpeciesOfInterest )
+  call outputSpeciesOfInterest( t, speciesOfInterest, speciesConcs )
 
   ! This outputs z, which is speciesConcs with all the constrained
   ! species removed.
@@ -412,8 +407,7 @@ PROGRAM ATCHEM2
       call outputRates( detailedRatesSpecies, reacDetailedRatesSpecies, reacDetailedRatesSpeciesLengths, t, lossRates, 0_SI )
     end if
 
-    concsOfSpeciesOfInterest = getConcForSpeciesOfInterest( speciesConcs, speciesOfInterest )
-    call outputSpeciesOfInterest( t, speciesOfInterest, concsOfSpeciesOfInterest )
+    call outputSpeciesOfInterest( t, speciesOfInterest, speciesConcs )
     call outputPhotolysisRates( t )
 
     ! Output instantaneous rates
@@ -475,7 +469,7 @@ PROGRAM ATCHEM2
   call FCVFREE()
   deallocate (speciesConcs, z)
   deallocate (reacDetailedRatesSpecies, prodDetailedRatesSpecies)
-  deallocate (concsOfSpeciesOfInterest, detailedRatesSpeciesName, speciesOfInterest)
+  deallocate (detailedRatesSpeciesName, speciesOfInterest)
   deallocate (instantaneousRates)
   deallocate (lossRates, productionRates)
   deallocate (clhs, clcoeff, crhs, crcoeff)

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -739,7 +739,7 @@ contains
   ! contains a list of the species we want to write to
   ! model/output/{production,loss}Rates.output Output the contents in
   ! r, with i as the length of r.
-  subroutine readProductsOrReactantsOfInterest( filename, r )
+  subroutine readDetailedRatesSpeciesNames( filename, r )
     use types_mod
     use storage_mod, only : maxSpecLength
     implicit none
@@ -763,7 +763,7 @@ contains
     end if
 
     return
-  end subroutine readProductsOrReactantsOfInterest
+  end subroutine readDetailedRatesSpeciesNames
 
   ! -----------------------------------------------------------------
   ! Read in parameters from file at input_file, and save the contents

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -330,17 +330,20 @@ contains
   ! Print each element of arrayOfConcs, with size arrayOfConcsSize.
   ! If any concentration is negative, then set it to zero before
   ! printing.
-  subroutine outputSpeciesOfInterest( t, specOutReqNames, arrayOfConcs )
+  subroutine outputSpeciesOfInterest( t, specOutReqNames, allSpeciesConcs )
     use types_mod
     use storage_mod, only : maxSpecLength
+    use config_functions_mod, only: getConcForSpeciesOfInterest
     implicit none
 
     real(kind=DP), intent(in) :: t
     character(len=maxSpecLength), intent(in) :: specOutReqNames(:)
-    real(kind=DP), intent(inout) :: arrayOfConcs(:)
+    real(kind=DP), intent(in) :: allSpeciesConcs(:)
+    real(kind=DP), allocatable :: arrayOfConcs(:)
     integer(kind=NPI) :: i
     logical :: first_time = .true.
 
+    arrayOfConcs = getConcForSpeciesOfInterest( allSpeciesConcs, specOutReqNames )
     if ( size( specOutReqNames ) /= size( arrayOfConcs ) ) then
       stop "size( specOutReqNames ) /= size( arrayOfConcs ) in outputSpeciesOfInterest()."
     end if


### PR DESCRIPTION
Skips the passing back and forth to the main program.