### PR TITLE
Make cache robust to periodic deletions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@
   before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; fi
     # if cached dirs exist, then continue. Otherwise, do the install from Homebrew
-    - if [[ "$TRAVIS_OS_NAME" == "osx" && -d /usr/local/Cellar/gcc@4.9/4.9.4_1 ]] ; then brew update ; brew install gcc@4.9 libffi gettext ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" && ! -d /usr/local/Cellar/gcc@4.9/4.9.4_1/bin ]] ; then brew update ; brew install gcc@4.9 libffi gettext ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@
         - numdiff
 
   before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; fi
     # if cached dirs exist, then continue. Otherwise, do the install from Homebrew
     - if [[ "$TRAVIS_OS_NAME" == "osx" && -d /usr/local/Cellar/gcc@4.9/4.9.4_1 ]] ; then brew update ; brew install gcc@4.9 libffi gettext ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi
     - ./tools/install/install_openlibm.sh $PWD

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@
         - numdiff
 
   before_install:
+    # if cached dirs exist, then continue. Otherwise, do the install from Homebrew
+    - if [[ "$TRAVIS_OS_NAME" == "osx" && -d /usr/local/Cellar/gcc@4.9/4.9.4_1 ]] ; then brew update ; brew install gcc@4.9 libffi gettext ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm '/usr/local/include/c++' ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi


### PR DESCRIPTION
Open-source builds have their Travis cache deleted every 28 days if not updated. The point of this PR is to make the build robust to this - check if the cache was successfully downloaded, and if it wasn't then do the Homebrew install (this will then rebuild the cache and make it good for another 28 days).

This will mean that once every 28 days a single Mac build on a PR somewhere will take longer than usual, but I think that is not an issue.