### PR TITLE
Create wrappers around getConstrainedQuantAtT()

### DIFF
--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -83,7 +83,7 @@ PROGRAM ATCHEM2
       use species_mod
       use constraints_mod
       use reaction_structure_mod
-      use interpolation_functions_mod, only : getConstrainedQuantAtT
+      use interpolation_functions_mod, only : getVariableConstrainedSpeciesConcentrationAtT
       use constraint_functions_mod
       implicit none
 
@@ -520,10 +520,11 @@ END PROGRAM ATCHEM2
 subroutine FCVFUN( t, y, ydot, ipar, rpar, ier )
   use types_mod
   use species_mod
-  use constraints_mod
+  use constraints_mod, only : getNumberOfConstrainedSpecies, numberOfVariableConstrainedSpecies, dataFixedY, &
+                              getConstrainedSpecies, setConstrainedConcs
   use reaction_structure_mod
   use interpolation_method_mod, only : getSpeciesInterpMethod
-  use interpolation_functions_mod, only : getConstrainedQuantAtT
+  use interpolation_functions_mod, only : getVariableConstrainedSpeciesConcentrationAtT, getConstrainedPhotoRatesAtT
   use constraint_functions_mod
   use solver_functions_mod, only : resid
   implicit none
@@ -548,8 +549,7 @@ subroutine FCVFUN( t, y, ydot, ipar, rpar, ier )
   do i = 1, numConSpec
     ! if it's a variable-concentration constrained species,
     if ( i <= numberOfVariableConstrainedSpecies ) then
-      call getConstrainedQuantAtT( t, datax, datay, speciesNumberOfPoints(i), &
-                                   getSpeciesInterpMethod(), i, constrainedConcs(i) )
+      call getVariableConstrainedSpeciesConcentrationAtT( t, i, constrainedConcs(i) )
     else
       constrainedConcs(i) = dataFixedY(i - numberOfVariableConstrainedSpecies)
     end if

--- a/src/constraintFunctions.f90
+++ b/src/constraintFunctions.f90
@@ -62,10 +62,10 @@ contains
   subroutine calcJFac( t, jFac )
     use types_mod
     use zenith_data_mod
-    use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints, jFacSpecies, numConstrainedPhotoRates, &
+    use photolysis_rates_mod, only : jFacSpecies, numConstrainedPhotoRates, &
                                      usePhotolysisConstants, constrainedPhotoNames, &
                                      jFacL, jFacM, jFacN, jFacTransmissionFactor
-    use interpolation_functions_mod, only : getConstrainedQuantAtT
+    use interpolation_functions_mod, only : getConstrainedPhotoRatesAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
     implicit none
 
@@ -95,8 +95,7 @@ contains
 
     ! GET CURRENT VALUE OF basePhotoRate
 
-    call getConstrainedQuantAtT( t, photoX, photoY, photoNumberOfPoints (basePhotoRateNum), &
-                                 getConditionsInterpMethod(), basePhotoRateNum, JFacSpeciesAtT )
+    call getConstrainedPhotoRatesAtT( t, basePhotoRateNum, JFacSpeciesAtT )
 
     if ( JFacSpeciesAtT == 0 ) then
       jFac = 0
@@ -200,7 +199,7 @@ contains
     use types_mod
     use storage_mod, only : maxEnvVarNameLength
     use env_vars_mod
-    use interpolation_functions_mod, only : getConstrainedQuantAtT
+    use interpolation_functions_mod, only : getConstrainedEnvVarAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
     use atmosphere_functions_mod, only : calcAirDensity, convertRHtoH2O
     use solar_functions_mod
@@ -289,8 +288,7 @@ contains
             write (stderr,*) 'ROOFOPEN should not be constrained.'
             stop
           end if
-          call getConstrainedQuantAtT( t, envVarX, envVarY, envVarNumberOfPoints(envVarNum), &
-                                       getConditionsInterpMethod(), envVarNum, this_env_val )
+          call getConstrainedEnvVarAtT( t, envVarNum, this_env_val )
 
           if (this_env_var_name == 'PRESS') pressure_set = .true.
           if (this_env_var_name == 'TEMP') temp_set = .true.

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -1152,7 +1152,7 @@ contains
     use directories_mod, only : param_dir, spec_constraints_dir
     use storage_mod, only : maxSpecLength, maxFilepathLength
     use config_functions_mod, only : getIndexWithinList
-    use interpolation_functions_mod, only : getConstrainedQuantAtT
+    use interpolation_functions_mod, only : getVariableConstrainedSpeciesConcentrationAtT
     use interpolation_method_mod , only : getSpeciesInterpMethod
     implicit none
 
@@ -1315,7 +1315,7 @@ contains
     allocate (concAtT(numberOfConstrainedSpecies))
     do i = 1, numberOfConstrainedSpecies
       if ( i <= numberOfVariableConstrainedSpecies ) then
-        call getConstrainedQuantAtT( t, datax, datay, speciesNumberOfPoints(i), getSpeciesInterpMethod(), i, concAtT(i) )
+        call getVariableConstrainedSpeciesConcentrationAtT( t, i, concAtT(i) )
       else
         concAtT(i) = dataFixedY(i - numberOfVariableConstrainedSpecies)
       end if

--- a/src/interpolationFunctions.f90
+++ b/src/interpolationFunctions.f90
@@ -21,6 +21,61 @@ module interpolation_functions_mod
 contains
 
   ! -----------------------------------------------------------------
+  ! Wrapper for getting variably constrained species values - this fills
+  ! just the ind-th element of concAtT with the value of the ind-th species
+  ! from that data.
+  subroutine getVariableConstrainedSpeciesConcentrationAtT( t, ind, concAtT )
+    use, intrinsic :: iso_fortran_env, only : stderr => error_unit
+    use types_mod
+    use constraints_mod, only : dataX, dataY, speciesNumberOfPoints
+    use interpolation_method_mod , only : getSpeciesInterpMethod
+    implicit none
+
+    real(kind=DP), intent(in) :: t
+    integer(kind=NPI) :: ind
+    real(kind=DP), intent(inout) :: concAtT
+
+    call getConstrainedQuantAtT( t, dataX, dataY, speciesNumberOfPoints(ind), getSpeciesInterpMethod(), ind, concAtT )
+
+  end subroutine getVariableConstrainedSpeciesConcentrationAtT
+
+  ! -----------------------------------------------------------------
+  ! Wrapper for getting variably constrained photolysis rates - this fills
+  ! photoRateAtT with the value of the ind-th rate from that data.
+  subroutine getConstrainedPhotoRatesAtT( t, ind, photoRateAtT )
+    use, intrinsic :: iso_fortran_env, only : stderr => error_unit
+    use types_mod
+    use photolysis_rates_mod, only : photoX, photoY, photoNumberOfPoints
+    use interpolation_method_mod , only : getConditionsInterpMethod
+    implicit none
+
+    real(kind=DP), intent(in) :: t
+    integer(kind=NPI) :: ind
+    real(kind=DP), intent(inout) :: photoRateAtT
+
+    call getConstrainedQuantAtT( t, photoX, photoY, photoNumberOfPoints(ind), getConditionsInterpMethod(), ind, photoRateAtT )
+
+  end subroutine getConstrainedPhotoRatesAtT
+
+  ! -----------------------------------------------------------------
+  ! Wrapper for getting constrained environment variables - this fills
+  ! envVarAtT with the value of the ind-th rate from that data.
+  subroutine getConstrainedEnvVarAtT( t, ind, envVarAtT )
+    use, intrinsic :: iso_fortran_env, only : stderr => error_unit
+    use types_mod
+    use env_vars_mod, only : envVarX, envVarY, envVarNumberOfPoints
+    use interpolation_method_mod , only : getConditionsInterpMethod
+    implicit none
+
+    real(kind=DP), intent(in) :: t
+    integer(kind=NPI) :: ind
+    real(kind=DP), intent(inout) :: envVarAtT
+
+    call getConstrainedQuantAtT( t, envVarX, envVarY, envVarNumberOfPoints(ind), getConditionsInterpMethod(), ind, envVarAtT )
+
+  end subroutine getConstrainedEnvVarAtT
+
+  ! -----------------------------------------------------------------
   ! This routine returns in concAtT the value of the requested
   ! quantity (referenced by the ind-th line of x, y) based upon
   ! the constraint data given and interpolation method given

--- a/src/parameterModules.f90
+++ b/src/parameterModules.f90
@@ -153,7 +153,7 @@ contains
     ! Use the local variable speciesInterpolationMethod to set the
     ! value speciesInterpMethod, the private member of MODULE
     ! interpolation_method_mod.
-    ! getSpeciesInterpMethod() is called by getConstrainedQuantAtT.
+    ! getSpeciesInterpMethod() is called by getVariableConstrainedSpeciesConcentrationAtT.
     ! Values:
     ! 1: Piecewise constant
     ! 2: Piecewise linear

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -166,10 +166,12 @@ contains
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
     use storage_mod, only : maxEnvVarNameLength
-    use photolysis_rates_mod
+    use photolysis_rates_mod, only : numConstantPhotoRates, constantPhotoNumbers, constantPhotoValues, &
+                                     numUnconstrainedPhotoRates, numConstrainedPhotoRates, j, ck, &
+                                     constrainedPhotoNumbers, usePhotolysisConstants
     use zenith_data_mod, only : cosx_below_threshold
     use env_vars_mod, only : ro2, envVarNames, currentEnvVarValues
-    use interpolation_functions_mod, only : getConstrainedQuantAtT
+    use interpolation_functions_mod, only : getConstrainedPhotoRatesAtT
     use interpolation_method_mod, only : getConditionsInterpMethod
     use output_functions_mod, only : ro2sum
     use constraint_functions_mod, only : calcPhotolysis, getEnvVarsAtT, getEnvVarNum
@@ -238,8 +240,7 @@ contains
       end do
 
       do i = 1, numConstrainedPhotoRates
-        call getConstrainedQuantAtT( t, photoX, photoY, photoNumberOfPoints(i), &
-                                     getConditionsInterpMethod(), i, photoRateAtT )
+        call getConstrainedPhotoRatesAtT( t, i, photoRateAtT )
         j(constrainedPhotoNumbers(i)) = photoRateAtT
       end do
     end if


### PR DESCRIPTION
1 for each of the 3 cases of species, environment variables, and photolysis rates.

This increases the modularity of the code (fewer module variables imported into functions) and reduces the risk of coding errors due to replicated code.