### PR TITLE
Remove the unnecessary variable size_of_j

### DIFF
--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -486,7 +486,6 @@ module photolysis_rates_mod
   integer(kind=NPI) :: maxNumberOfPhotoDataPoints
   real(kind=DP), allocatable :: photoX(:,:), photoY(:,:)
   integer(kind=NPI), allocatable :: photoNumberOfPoints(:)
-  integer(kind=NPI) :: size_of_j
   integer(kind=SI) :: PR_type
   real(kind=DP) :: jFacL, jFacM, jFacN, jFacTransmissionFactor
 
@@ -528,9 +527,10 @@ contains
               transmissionFactor(numUnconstrainedPhotoRates))
   end subroutine allocate_unconstrained_photolysis_rates_variables
 
-  subroutine allocate_photolysis_j()
+  subroutine allocate_photolysis_j( size_of_j )
     implicit none
 
+    integer(kind=NPI), intent(in) :: size_of_j
     allocate (j(size_of_j))
     j(:) = 0.0_DP
   end subroutine allocate_photolysis_j

--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -329,7 +329,7 @@ contains
   subroutine readPhotolysisNumbers()
     use, intrinsic :: iso_fortran_env, only : stderr => error_unit
     use types_mod
-    use photolysis_rates_mod, only : totalNumPhotos, photoNumbers, size_of_j, &
+    use photolysis_rates_mod, only : totalNumPhotos, photoNumbers, &
                                      allocate_photolysis_numbers_variables, allocate_photolysis_j
     use directories_mod, only : mcm_dir
     use storage_mod, only : maxFilepathLength
@@ -358,8 +358,7 @@ contains
       end if
     end do
     if ( allocated_j .eqv. .false. ) then
-      size_of_j = maxval(photoNumbers)
-      call allocate_photolysis_j()
+      call allocate_photolysis_j(maxval(photoNumbers))
       allocated_j = .true.
     end if
     close (10, status='keep')


### PR DESCRIPTION
Remove the unnecessary variable `size_of_j` from the `photolysis_rates_mod` - keep it as an input variable to the function `allocate_photolysis_j()`.