### PR TITLE
Fix missing indent and format tests from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@
   script:
     - ./atchem2
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then bash <(curl -s https://codecov.io/bash) -F build ; fi
+    - make formattest
+    - make styletest
     - make clean
     - make unittests
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then bash <(curl -s https://codecov.io/bash) -F unittests ; fi

--- a/src/configFunctions.f90
+++ b/src/configFunctions.f90
@@ -122,7 +122,7 @@ contains
 
           if ( rCounter == 0_NPI ) then
             rCounter = 1_NPI
-          elseif ( chs(1,j) /= r(i, rCounter)%reaction ) then
+          elseif ( chs(1, j) /= r(i, rCounter)%reaction ) then
             rCounter = rCounter + 1_NPI
           end if
           r(i, rCounter)%reaction = chs(1, j)

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -51,7 +51,7 @@ module types_mod
   end interface
 
 contains
-  function reaction_frequency_pair_equals(a,b) result ( res )
+  function reaction_frequency_pair_equals( a, b ) result ( res )
     implicit none
     type(reaction_frequency_pair), intent(in) :: a, b
     logical :: res

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -50,14 +50,14 @@ module types_mod
     module procedure reaction_frequency_pair_equals
   end interface
 
-  contains
-    function reaction_frequency_pair_equals(a,b) result ( res )
-      implicit none
-      type(reaction_frequency_pair), intent(in) :: a, b
-      logical :: res
+contains
+  function reaction_frequency_pair_equals(a,b) result ( res )
+    implicit none
+    type(reaction_frequency_pair), intent(in) :: a, b
+    logical :: res
 
-      res = ( ( a%reaction == b%reaction ) .and. ( a%frequency == b%frequency ) )
-    end function reaction_frequency_pair_equals
+    res = ( ( a%reaction == b%reaction ) .and. ( a%frequency == b%frequency ) )
+  end function reaction_frequency_pair_equals
 end module types_mod
 
 ! ******************************************************************** !

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -292,7 +292,7 @@ contains
       end if
 
       do j = 1, arrayLen(i)
-        if ( ( r(i, j)%reaction /= -1_NPI ) .and. ( r(i,j)%frequency /= 0_NPI ) ) then
+        if ( ( r(i, j)%reaction /= -1_NPI ) .and. ( r(i, j)%frequency /= 0_NPI ) ) then
           reaction = getReaction( speciesNames, r(i, j)%reaction )
           ! r contains the occurences of each of the detailed species in reactions.
           ! r should have row lengths as in arrayLen, so all accesss to r(i,j) should

--- a/tools/fix_indent.py
+++ b/tools/fix_indent.py
@@ -121,7 +121,8 @@ with open(out_filename, 'w') as output_file:
                 # match if, do, subroutine, function, module, else, contains, program, interface, select, case, type (definition, not instantiation) to set the next line indent higher
                 if re.search('\s*IF.+THEN', to_output, flags=re.IGNORECASE) or re.match('^\s*else\s*', to_output, flags=re.IGNORECASE) or re.match('^\s*do\s*', to_output, flags=re.IGNORECASE) \
                     or re.match('^\s*subroutine\s*', to_output, flags=re.IGNORECASE) or re.match('^\s*function\s*', to_output, flags=re.IGNORECASE) \
-                    or re.match('^\s*module\s*', to_output, flags=re.IGNORECASE) or re.match('^\s*contains\s*', to_output, flags=re.IGNORECASE) \
+                    or ( re.match('^\s*module\s*', to_output, flags=re.IGNORECASE) and not re.match('^\s*module procedure \s*', to_output, flags=re.IGNORECASE) ) \
+                    or re.match('^\s*contains\s*', to_output, flags=re.IGNORECASE) \
                     or re.match('^\s*program\s*', to_output, flags=re.IGNORECASE) or re.match('^\s*interface\s*', to_output, flags=re.IGNORECASE) \
                     or re.match('^\s*pure function\s*', to_output, flags=re.IGNORECASE) or re.match('^\s*select\s*', to_output, flags=re.IGNORECASE) \
                     or re.match('^\s*case\s*', to_output, flags=re.IGNORECASE) or re.match('^\s*type\s+', to_output, flags=re.IGNORECASE):


### PR DESCRIPTION
Re-add style and formatting tests to .travis.yml. Also update the indenting script to handle 'module procedure' declarations. Apply indenting fix to src/dataStructures.f90.