### PR TITLE
Add header to final column of rates output

### DIFF
--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -260,6 +260,7 @@ contains
     character(len=maxSpecLength), allocatable :: speciesNames(:)
     integer(kind=NPI) :: i, j, output_file_number
     character(len=maxReactionStringLength) :: reaction
+    character(len=maxReactionStringLength) :: header
     logical :: first_time = .true.
 
     if ( size( r, 1 ) /= size( arrayLen ) ) then
@@ -267,8 +268,9 @@ contains
     end if
     ! Add headers at the first call
     if ( first_time .eqv. .true. ) then
-      write (56,*) '          time speciesNumber speciesName reactionNumber           rate'
-      write (60,*) '          time speciesNumber speciesName reactionNumber           rate'
+      header = "          time speciesNumber speciesName reactionNumber           rate  reaction"
+      write (56,*) header
+      write (60,*) header
       first_time = .false.
     end if
 

--- a/travis/tests/firstorder/output/lossRates.output.cmp
+++ b/travis/tests/firstorder/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   1.000000E+000             1           O              1  9.236169E-001  O=O3
   2.000000E+000             1           O              1  9.078467E-001  O=O3
   3.000000E+000             1           O              1  9.078467E-001  O=O3

--- a/travis/tests/firstorder/output/productionRates.output.cmp
+++ b/travis/tests/firstorder/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   1.000000E+000             2          O3              1  9.236169E-001  O=O3
   2.000000E+000             2          O3              1  9.078467E-001  O=O3
   3.000000E+000             2          O3              1  9.078467E-001  O=O3

--- a/travis/tests/full/output/lossRates.output.cmp
+++ b/travis/tests/full/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   7.200000E+003             8          OH             16  0.000000E+000  OH+O3=HO2
   7.200000E+003             8          OH             17  0.000000E+000  OH+H2=HO2
   7.200000E+003             8          OH             18  0.000000E+000  OH+CO=HO2

--- a/travis/tests/full/output/productionRates.output.cmp
+++ b/travis/tests/full/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   7.200000E+003             8          OH             15  0.000000E+000  O1D=OH+OH
   7.200000E+003             8          OH             20  0.000000E+000  HO2+O3=OH
   7.200000E+003             8          OH             27  0.000000E+000  HO2+NO=OH+NO2

--- a/travis/tests/secondorder/output/lossRates.output.cmp
+++ b/travis/tests/secondorder/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   1.000000E+000             1           O              1  1.778894E+000  O+O=O3+O3
   2.000000E+000             1           O              1  1.730847E+000  O+O=O3+O3
   3.000000E+000             1           O              1  1.607989E+000  O+O=O3+O3

--- a/travis/tests/secondorder/output/productionRates.output.cmp
+++ b/travis/tests/secondorder/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   1.000000E+000             2          O3              1  1.778894E+000  O+O=O3+O3
   2.000000E+000             2          O3              1  1.730847E+000  O+O=O3+O3
   3.000000E+000             2          O3              1  1.607989E+000  O+O=O3+O3

--- a/travis/tests/short/output/lossRates.output.cmp
+++ b/travis/tests/short/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             9         HO2             20  0.000000E+000  HO2+O3=OH
   4.380000E+004             9         HO2             21  0.000000E+000  OH+HO2=
   4.380000E+004             9         HO2             22  0.000000E+000  HO2+HO2=H2O2

--- a/travis/tests/short/output/productionRates.output.cmp
+++ b/travis/tests/short/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             9         HO2             16  0.000000E+000  OH+O3=HO2
   4.380000E+004             9         HO2             17  0.000000E+000  OH+H2=HO2
   4.380000E+004             9         HO2             18  0.000000E+000  OH+CO=HO2

--- a/travis/tests/short_dense/output/lossRates.output.cmp
+++ b/travis/tests/short_dense/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             9         HO2             20  0.000000E+000  HO2+O3=OH
   4.380000E+004             9         HO2             21  0.000000E+000  OH+HO2=
   4.380000E+004             9         HO2             22  0.000000E+000  HO2+HO2=H2O2

--- a/travis/tests/short_dense/output/productionRates.output.cmp
+++ b/travis/tests/short_dense/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             9         HO2             16  0.000000E+000  OH+O3=HO2
   4.380000E+004             9         HO2             17  0.000000E+000  OH+H2=HO2
   4.380000E+004             9         HO2             18  0.000000E+000  OH+CO=HO2

--- a/travis/tests/short_end_of_day/output/lossRates.output.cmp
+++ b/travis/tests/short_end_of_day/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   8.520000E+004             9         HO2             20  0.000000E+000  HO2+O3=OH
   8.520000E+004             9         HO2             21  0.000000E+000  OH+HO2=
   8.520000E+004             9         HO2             22  0.000000E+000  HO2+HO2=H2O2

--- a/travis/tests/short_end_of_day/output/productionRates.output.cmp
+++ b/travis/tests/short_end_of_day/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   8.520000E+004             9         HO2             16  0.000000E+000  OH+O3=HO2
   8.520000E+004             9         HO2             17  0.000000E+000  OH+H2=HO2
   8.520000E+004             9         HO2             18  0.000000E+000  OH+CO=HO2

--- a/travis/tests/short_ext1/output/lossRates.output.cmp
+++ b/travis/tests/short_ext1/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             16  5.897339E+006  OH+O3=HO2
   4.380000E+004             8          OH             17  6.862135E-001  OH+H2=HO2
   4.380000E+004             8          OH             18  3.806139E+002  OH+CO=HO2

--- a/travis/tests/short_ext1/output/productionRates.output.cmp
+++ b/travis/tests/short_ext1/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             15  8.278455E+006  O1D=OH+OH
   4.380000E+004             8          OH             20  7.122786E+005  HO2+O3=OH
   4.380000E+004             8          OH             27  2.662855E+006  HO2+NO=OH+NO2

--- a/travis/tests/short_ext2/output/lossRates.output.cmp
+++ b/travis/tests/short_ext2/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             16  5.875830E+006  OH+O3=HO2
   4.380000E+004             8          OH             17  6.759150E-001  OH+H2=HO2
   4.380000E+004             8          OH             18  3.742862E+002  OH+CO=HO2

--- a/travis/tests/short_ext2/output/productionRates.output.cmp
+++ b/travis/tests/short_ext2/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             15  8.240901E+006  O1D=OH+OH
   4.380000E+004             8          OH             20  7.104474E+005  HO2+O3=OH
   4.380000E+004             8          OH             27  2.659884E+006  HO2+NO=OH+NO2

--- a/travis/tests/short_ext3/output/lossRates.output.cmp
+++ b/travis/tests/short_ext3/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             16  1.195273E+006  OH+O3=HO2
   4.380000E+004             8          OH             17  1.738094E-002  OH+H2=HO2
   4.380000E+004             8          OH             18  3.353630E+000  OH+CO=HO2

--- a/travis/tests/short_ext3/output/productionRates.output.cmp
+++ b/travis/tests/short_ext3/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             15  1.036823E+006  O1D=OH+OH
   4.380000E+004             8          OH             20  2.161390E+005  HO2+O3=OH
   4.380000E+004             8          OH             27  9.647831E+005  HO2+NO=OH+NO2

--- a/travis/tests/short_ext4/output/lossRates.output.cmp
+++ b/travis/tests/short_ext4/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             16  9.908277E+005  OH+O3=HO2
   4.380000E+004             8          OH             17  1.164812E-002  OH+H2=HO2
   4.380000E+004             8          OH             18  2.084669E+000  OH+CO=HO2

--- a/travis/tests/short_ext4/output/productionRates.output.cmp
+++ b/travis/tests/short_ext4/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             8          OH             15  8.352604E+005  O1D=OH+OH
   4.380000E+004             8          OH             20  1.878405E+005  HO2+O3=OH
   4.380000E+004             8          OH             27  8.095811E+005  HO2+NO=OH+NO2

--- a/travis/tests/short_no_pre/output/lossRates.output.cmp
+++ b/travis/tests/short_no_pre/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             9         HO2             20  0.000000E+000  HO2+O3=OH
   4.380000E+004             9         HO2             21  0.000000E+000  OH+HO2=
   4.380000E+004             9         HO2             22  0.000000E+000  HO2+HO2=H2O2

--- a/travis/tests/short_no_pre/output/productionRates.output.cmp
+++ b/travis/tests/short_no_pre/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   4.380000E+004             9         HO2             16  0.000000E+000  OH+O3=HO2
   4.380000E+004             9         HO2             17  0.000000E+000  OH+H2=HO2
   4.380000E+004             9         HO2             18  0.000000E+000  OH+CO=HO2

--- a/travis/tests/spec_no_env_yes1/output/lossRates.output.cmp
+++ b/travis/tests/spec_no_env_yes1/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   3.600000E+003             8          OH             16  0.000000E+000  OH+O3=HO2
   3.600000E+003             8          OH             17  0.000000E+000  OH+H2=HO2
   3.600000E+003             8          OH             18  0.000000E+000  OH+CO=HO2

--- a/travis/tests/spec_no_env_yes1/output/productionRates.output.cmp
+++ b/travis/tests/spec_no_env_yes1/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   3.600000E+003             8          OH             15  0.000000E+000  O1D=OH+OH
   3.600000E+003             8          OH             20  0.000000E+000  HO2+O3=OH
   3.600000E+003             8          OH             27  0.000000E+000  HO2+NO=OH+NO2

--- a/travis/tests/spec_yes_env_no_with_jfac/output/lossRates.output.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   3.640000E+004             8          OH             16  1.108312E+005  OH+O3=HO2
   3.640000E+004             8          OH             17  1.482736E-002  OH+H2=HO2
   3.640000E+004             8          OH             18  1.088540E+000  OH+CO=HO2

--- a/travis/tests/spec_yes_env_no_with_jfac/output/productionRates.output.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   3.640000E+004             8          OH             15  3.417774E+006  O1D=OH+OH
   3.640000E+004             8          OH             20  1.436212E+003  HO2+O3=OH
   3.640000E+004             8          OH             27  5.463667E+005  HO2+NO=OH+NO2

--- a/travis/tests/spec_yes_env_no_with_jfac_fixed/output/lossRates.output.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac_fixed/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   3.640000E+004             8          OH             16  8.433718E+004  OH+O3=HO2
   3.640000E+004             8          OH             17  6.733686E-003  OH+H2=HO2
   3.640000E+004             8          OH             18  4.916729E-001  OH+CO=HO2

--- a/travis/tests/spec_yes_env_no_with_jfac_fixed/output/productionRates.output.cmp
+++ b/travis/tests/spec_yes_env_no_with_jfac_fixed/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   3.640000E+004             8          OH             15  2.740349E+006  O1D=OH+OH
   3.640000E+004             8          OH             20  1.277992E+003  HO2+O3=OH
   3.640000E+004             8          OH             27  4.135080E+005  HO2+NO=OH+NO2

--- a/travis/tests/static/output/lossRates.output.cmp
+++ b/travis/tests/static/output/lossRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   7.320000E+004             1           O              1  9.398333E+008  O=O3
   7.320000E+004             2          O3              2  9.398333E+008  O3=O
   1.032000E+005             1           O              1  9.398333E+008  O=O3

--- a/travis/tests/static/output/productionRates.output.cmp
+++ b/travis/tests/static/output/productionRates.output.cmp
@@ -1,4 +1,4 @@
-           time speciesNumber speciesName reactionNumber           rate
+           time speciesNumber speciesName reactionNumber           rate  reaction
   7.320000E+004             1           O              2  9.398333E+008  O3=O
   7.320000E+004             2          O3              1  9.398333E+008  O=O3
   1.032000E+005             1           O              2  9.398333E+008  O3=O


### PR DESCRIPTION
Add 'reaction' as a header to the final column in `{loss,production}Rates.cmp` in the travis tests, and alter `outputRates()` to output this new column header.