### PR TITLE
Remove bind(c) from pointer

### DIFF
--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -28,7 +28,7 @@ module solver_functions_mod
     end subroutine called_proc
   end interface
 
-  procedure(called_proc), bind(c), pointer :: proc
+  procedure(called_proc), pointer :: proc
 
 contains
 


### PR DESCRIPTION
This allows compilation with armflang, as it's not totally necessary - we never call out to c.