### PR TITLE
Update install_numdiff.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@
 
   before_install:
     # if cached dirs exist, then continue. Otherwise, do the install from Homebrew
-    - if [[ "$TRAVIS_OS_NAME" == "osx" && ! -d /usr/local/Cellar/gcc@4.9/4.9.4_1/bin ]] ; then brew update ; brew install gcc@4.9 libffi gettext ; brew link gettext --force ;  fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" && ! -d /usr/local/Cellar/gcc@4.9/4.9.4_1/bin ]] ; then brew update ; brew install gcc@4.9 libffi gettext ;  fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DYLD_LIBRARY_PATH=$PWD/cvode/lib:$PWD/openlibm-0.4.1 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./tools/install/install_cvode.sh $PWD /usr/local/Cellar/gcc@4.9/4.9.4_1/bin/gfortran-4.9 ; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./tools/install/install_cvode.sh $PWD /usr/bin/gfortran ; fi

--- a/tools/install/install_numdiff.sh
+++ b/tools/install/install_numdiff.sh
@@ -37,7 +37,7 @@ rm numdiff-5.8.1.tar.gz
 cd numdiff-5.8.1/
 OS=$(uname -s)
 if [ "$OS" == 'Darwin' ]; then
-  ./configure --prefix=$1/numdiff CPPFLAGS=-I/usr/local/Cellar/gettext/0.19.8.1/include/ LDFLAGS=-L/usr/local/Cellar/gettext/0.19.8.1/lib
+  ./configure --prefix=$1/numdiff CPPFLAGS=-I/usr/local/Cellar/gettext/0.20.1/include/ LDFLAGS=-L/usr/local/Cellar/gettext/0.20.1/lib
 else
   ./configure --prefix=$1/numdiff
 fi


### PR DESCRIPTION
Point to the newer version of gettext (0.20.1) on OSX.