### PR TITLE
Truncation changes

### DIFF
--- a/doc/latex/Credits.tex
+++ b/doc/latex/Credits.tex
@@ -41,7 +41,6 @@ created at the \textbf{University of Leeds} by:
 \item Jenny Young
 \item Peter Jimack
 \item Mike Pilling
-\item Alfred Mayhew
 \end{itemize}
 
 Model evaluation and testing of AtChem-online was performed by Andrew
@@ -61,6 +60,7 @@ Thanks for their support, feedback, and contributions to:
 \item Paul Monks
 \item Jon Wakelin
 \item Robert Woodward-Massey
+\item Alfred Mayhew
 \end{itemize}
 
 Special thanks to Harald Stark (University of Colorado-Boulder, USA)

--- a/doc/latex/Credits.tex
+++ b/doc/latex/Credits.tex
@@ -41,6 +41,7 @@ created at the \textbf{University of Leeds} by:
 \item Jenny Young
 \item Peter Jimack
 \item Mike Pilling
+\item Alfred Mayhew
 \end{itemize}
 
 Model evaluation and testing of AtChem-online was performed by Andrew

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -71,7 +71,7 @@ module storage_mod
   implicit none
   save
 
-  integer(kind=DI), parameter :: maxSpecLength=10
+  integer(kind=DI), parameter :: maxSpecLength=50
   integer(kind=DI), parameter :: maxPhotoRateNameLength=6
   integer(kind=DI), parameter :: maxEnvVarNameLength=9
   integer(kind=DI), parameter :: maxEnvVarLength=15

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -294,7 +294,7 @@ contains
           ! r contains the occurences of each of the detailed species in reactions.
           ! r should have row lengths as in arrayLen, so all accesss to r(i,j) should
           ! be valid.
-          write (output_file_number, '(ES15.6E3, I14, A12, I15, ES15.6E3, A, A)') t, rSpecies(i), &
+          write (output_file_number, '(ES15.6E3, I14, A50, I15, ES15.6E3, A, A)') t, rSpecies(i), &
                                                                                   trim( speciesNames(rSpecies(i)) ), &
                                                                                   r(i, j)%reaction, &
                                                                                   r(i, j)%frequency * p(r(i, j)%reaction), &
@@ -356,7 +356,7 @@ contains
     end if
 
     if ( first_time .eqv. .true. ) then
-      write (50, '(100A15) ') 't', (trim( specOutReqNames(i) ), i = 1, size( specOutReqNames ))
+      write (50, '(1000A50) ') 't', (trim( specOutReqNames(i) ), i = 1, size( specOutReqNames ))
       first_time = .false.
     end if
 
@@ -365,7 +365,7 @@ contains
         arrayOfConcs(i) = 0.0_DP
       end if
     end do
-    write (50, '(100 (ES15.6E3)) ') t, (arrayOfConcs(i), i = 1, size( arrayOfConcs ))
+    write (50, '(1000 (ES50.6E3)) ') t, (arrayOfConcs(i), i = 1, size( arrayOfConcs ))
 
     return
   end subroutine outputSpeciesOfInterest

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -294,7 +294,7 @@ contains
           ! r contains the occurences of each of the detailed species in reactions.
           ! r should have row lengths as in arrayLen, so all accesss to r(i,j) should
           ! be valid.
-          write (output_file_number, '(ES15.6E3, I14, A50, I15, ES15.6E3, A, A)') t, rSpecies(i), &
+          write (output_file_number, '(ES15.6E3, I14, A52, I15, ES15.6E3, A, A)') t, rSpecies(i), &
                                                                                   trim( speciesNames(rSpecies(i)) ), &
                                                                                   r(i, j)%reaction, &
                                                                                   r(i, j)%frequency * p(r(i, j)%reaction), &

--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -67,7 +67,7 @@ endif
 # set compilation flags for each compiler
 ifeq ($(FORT_COMP),gfortran)
 FFLAGS       =  -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
-FSHAREDFLAGS =  -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
+FSHAREDFLAGS =  -ffree-line-length-none -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
 LIBDIR       =  /usr/lib/:$(CVODELIB)
 endif
 ifeq ($(FORT_COMP),ifort)


### PR DESCRIPTION
Hi,
This request relates to the [recent issue I raised](https://github.com/AtChem/AtChem2/issues/427), and takes two parts (two commits).

I was running into issues with the maximum size of species names allowed. I have increased the maximum species name length, and the maximum length in the output files (concentration and rate outputs), to 50 characters. Clearly this limit is arbitrary, and with the fixed width of columns in the output file this value does alter the readability of the speciesConcentrations.output file. I also increased the grouping of species at the top of the speciesConcentrations.output file from 100 species before a newline character to 1000. Again, this is subjective as a limit but I think that over 100 compounds isn't a ridiculous amount, and it makes processing the output file more difficult to have groupings into 100 species.

Secondly, I added the -ffree-line-length-none flag to the Makefile.skel file to prevent lines being truncated if they are too long in the mechanism file. I ran into this issue because my rate expressions were too long. I added this flag to my Makefile directly previously so have not tested using the .skel file when building a new Makefile, but I'm assuming this should pose no issue.

Thanks,
Alfie