### PR TITLE
Fix c-bind bug in update_p()

### DIFF
--- a/build/mech_converter.py
+++ b/build/mech_converter.py
@@ -432,8 +432,8 @@ contains
     subroutine update_p(p, q, TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J, RO2) bind(c,name='update_p')
 
         integer, parameter :: DP = selected_real_kind( p = 15, r = 307 )
-           real(c_double), intent(inout) :: p(:), q(:)
-        real(c_double), intent(in) :: TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J(:), RO2
+           real(c_double), intent(inout) :: p(*), q(*)
+        real(c_double), intent(in) :: TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J(*), RO2
         """)
         # Write out Generic Rate Coefficients and Complex reactions
         for item in mechanism_rates_coeff_list:

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -25,8 +25,8 @@ module solver_functions_mod
   abstract interface
     subroutine called_proc( i, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16 ) bind ( c )
       use, intrinsic :: iso_c_binding
-      real(c_double), intent(inout) :: i(:), i2(:)
-      real(c_double), intent(in) :: i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15(:), i16
+      real(c_double), intent(inout) :: i(*), i2(*)
+      real(c_double), intent(in) :: i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15(*), i16
     end subroutine called_proc
   end interface
 


### PR DESCRIPTION
Use assumed-size arrays (*) rather than assumed-shape (:) for the c-bind `update_p()` function, as the latter is not standards-compliant and does not offer consistent access to lbound. Older versions of `gfortran` did not raise this as an issue, possibly because they have different minimum standards.

This should close 

Note that upgrading Ubuntu versions also changes the gfortran version: (from https://www.scivision.dev/major-gfortran-changes/)

> Ubuntu 20.04 default: gfortran-9
> Ubuntu 18.04 default: gfortran-7

which likely explains the difference in behaviour when upgrading. I can't find any information about what differences there are in this specific case though - the changelogs don't mention anything that looks relevant.

This should address #431 , #435 , and #437 . Could one or more of @ShenAlbert, @jjunum, @vinthony, @xiaoky97, @AlfredMayhew , or @Ekimmai please test this to see whether it fixes their issue?