### PR TITLE
Fix missing code coverage files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./tools/install/install_cvode.sh $PWD $(which gfortran-${{ matrix.fortran }})
 
+      # ubuntu only
+      - name: Check for gcov
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          which gcov
+          gcov --version
+          ls $(which gcov)
+
       # macOS only
       - name: Install cvode (macOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
           # Run Atchem2
           ./atchem2
           # Upload 'build' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" ]]; then ln -f -s /usr/bin/gcov-{{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
+          echo  ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov
+          if [[ "$RUNNER_OS" == "Linux" ]]; then ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           export PATH=$PATH:$PWD/numdiff/bin
           make unittests
           # Upload 'unittests' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
+          # if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
           make clean
           # Run full build tests - this will upload 'tests' coverage to codecov for each test
           make tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile
+        if: matrix.fortran == '8'
         env:
           FORT_VERSION: ${{ matrix.fortran }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           which gcov
           gcov --version
-          ls /usr/bin/gcov*
+          ls -al /usr/bin/gcov*
 
       # macOS only
       - name: Install cvode (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           # Run Atchem2
           ./atchem2
           # Upload 'build' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
+          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile
@@ -95,7 +95,7 @@ jobs:
           export PATH=$PATH:$PWD/numdiff/bin
           make unittests
           # Upload 'unittests' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
+          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
           make clean
           # Run full build tests - this will upload 'tests' coverage to codecov for each test
           make tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           export PATH=$PATH:$PWD/numdiff/bin
           make unittests
           # Upload 'unittests' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" ]]; then bash <(curl -s https://codecov.io/bash) -F unittests ; fi
+          if [[ "$RUNNER_OS" == "Linux" ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
           make clean
           # Run full build tests - this will upload 'tests' coverage to codecov for each test
           make tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,7 @@ jobs:
       # ubuntu only
       - name: Install cvode (ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo ln -f -s /usr/bin/gfortran-${{ matrix.fortran }} /usr/bin/gfortran
-          ./tools/install/install_cvode.sh $PWD $(which gfortran-${{ matrix.fortran }})
-
-      # ubuntu only
-      - name: Check for gcov
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          which gcov
-          gcov --version
-          ls -al /usr/bin/gcov*
+        run: ./tools/install/install_cvode.sh $PWD $(which gfortran-${{ matrix.fortran }})
 
       # macOS only
       - name: Install cvode (macOS)
@@ -86,7 +76,7 @@ jobs:
           # Run Atchem2
           ./atchem2
           # Upload 'build' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
+          if [[ "$RUNNER_OS" == "Linux" ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile
@@ -98,7 +88,7 @@ jobs:
           export PATH=$PATH:$PWD/numdiff/bin
           make unittests
           # Upload 'unittests' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
+          if [[ "$RUNNER_OS" == "Linux" ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
           make clean
           # Run full build tests - this will upload 'tests' coverage to codecov for each test
           make tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           which gcov
           gcov --version
-          ls $(which gcov)
+          ls /usr/bin/gcov*
 
       # macOS only
       - name: Install cvode (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           # Run Atchem2
           ./atchem2
           # Upload 'build' coverage to codecov
-          if [[ "$RUNNER_OS" == "Linux" ]]; then bash <(curl -s https://codecov.io/bash) -F build ; fi
+          if [[ "$RUNNER_OS" == "Linux" ]]; then ln -f -s /usr/bin/gcov-{{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           export PATH=$PATH:$PWD/numdiff/bin
           make unittests
           # Upload 'unittests' coverage to codecov
-          # if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
+          if [[ "$RUNNER_OS" == "Linux" && ${{ matrix.fortran }} == '8' ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F unittests ; fi
           make clean
           # Run full build tests - this will upload 'tests' coverage to codecov for each test
           make tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,7 @@ jobs:
           # Run Atchem2
           ./atchem2
           # Upload 'build' coverage to codecov
-          echo  ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov
-          if [[ "$RUNNER_OS" == "Linux" ]]; then ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
+          if [[ "$RUNNER_OS" == "Linux" ]]; then sudo ln -f -s /usr/bin/gcov-${{ matrix.fortran }} /usr/bin/gcov ; bash <(curl -s https://codecov.io/bash) -F build ; fi
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
       
       - name: Run tests
         # Set FORT_VERSION for use inside the Makefile
-        if: matrix.fortran == '8'
         env:
           FORT_VERSION: ${{ matrix.fortran }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       # ubuntu only
       - name: Install cvode (ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: ./tools/install/install_cvode.sh $PWD $(which gfortran-${{ matrix.fortran }})
+        run: |
+          sudo ln -f -s /usr/bin/gfortran-${{ matrix.fortran }} /usr/bin/gfortran
+          ./tools/install/install_cvode.sh $PWD $(which gfortran-${{ matrix.fortran }})
 
       # ubuntu only
       - name: Check for gcov

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -205,7 +205,7 @@ $this_file_failures"
   echo "$this_test_failures"
 done
 
-if [[ "$RUNNER_OS" == "Linux"  && ${{ matrix.fortran }} == '8' ]]; then bash <(curl -s https://codecov.io/bash) -F tests ; fi
+if [[ "$RUNNER_OS" == "Linux" ]]; then bash <(curl -s https://codecov.io/bash) -F tests ; fi
 
 # After all tests are run, exit with a FAIL if $fail_counter>0, otherwise PASS.
 if [[ "$fail_counter" -gt 0 ]]; then

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -205,7 +205,7 @@ $this_file_failures"
   echo "$this_test_failures"
 done
 
-if [[ "$RUNNER_OS" == "Linux" ]]; then bash <(curl -s https://codecov.io/bash) -F tests ; fi
+if [[ "$RUNNER_OS" == "Linux"  && ${{ matrix.fortran }} == '8' ]]; then bash <(curl -s https://codecov.io/bash) -F tests ; fi
 
 # After all tests are run, exit with a FAIL if $fail_counter>0, otherwise PASS.
 if [[ "$fail_counter" -gt 0 ]]; then

--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -65,11 +65,11 @@ endif
 endif
 
 # set compilation flags for each compiler
-ifeq ($(FORT_COMP),gfortran)
+ifeq ($(FORTC),"gnu")
 FFLAGS       =  -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
 FSHAREDFLAGS =  -ffree-line-length-none -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
 endif
-ifeq ($(FORT_COMP),ifort)
+ifeq ($(FORTC),"intel")
 FFLAGS       = -free -warn
 FSHAREDFLAGS =
 endif

--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -66,7 +66,7 @@ endif
 
 # set compilation flags for each compiler
 ifeq ($(FORTC),"gnu")
-FFLAGS       =  -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
+FFLAGS       =  -O0 -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
 FSHAREDFLAGS =  -ffree-line-length-none -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
 endif
 ifeq ($(FORTC),"intel")

--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -66,7 +66,7 @@ endif
 
 # set compilation flags for each compiler
 ifeq ($(FORTC),"gnu")
-FFLAGS       =  -O0 -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
+FFLAGS       =  -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
 FSHAREDFLAGS =  -ffree-line-length-none -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
 endif
 ifeq ($(FORTC),"intel")


### PR DESCRIPTION
Use FORTC in Makefile.skel to test for the fortran compiler family (rather than the exact name of the executable). This should ensure code coverage is tracked on ubuntu Actions runs.