### PR TITLE
Make -O2 the default optimisation level on gfortran.

### DIFF
--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -66,7 +66,7 @@ endif
 
 # set compilation flags for each compiler
 ifeq ($(FORTC),"gnu")
-FFLAGS       =  -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
+FFLAGS       =  -O2 -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
 FSHAREDFLAGS =  -ffree-line-length-none -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
 endif
 ifeq ($(FORTC),"intel")


### PR DESCRIPTION
In a very small amount of testing documented at https://github.com/AtChem/AtChem2/issues/436#issuecomment-771136176, this should provide a 2x speedup (and I think this is a conservative estimate in most cases, but don't have the data to back that up, just experience!)