### PR TITLE
Catch missing RO2 species error when prepping

### DIFF
--- a/build/mech_converter.py
+++ b/build/mech_converter.py
@@ -463,7 +463,15 @@ end module mechanism_mod
             # This code only executes if the break is NOT called, i.e. if the loop runs to completion without the RO2 being
             # found in the species list
             else:
-                ro2_file.write('0 ! error RO2 not in mechanism: ' + ro2List_i + '\n')
+                error_message = ' ****** Warning: RO2 species "' + str(ro2List_i.strip()) + '" NOT found in the mechanism. Please check the RO2 section of your mechansm file for incorrect species names! ******'
+                error_message = ''.join([
+                  ' ****** ',
+                  'Error: RO2 species "',
+                  str(ro2List_i.strip()),
+                  '" NOT found in the mechanism. Please check the RO2 section',
+                  ' of your mechanism file for incorrect species names!',
+                  ' ******'])
+                raise RuntimeError(error_message)
 
 
 ## ------------------------------------------------------------------ ##
@@ -492,4 +500,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except RuntimeError as e:
+        print(str(e))
+        sys.exit(os.EX_DATAERR)

--- a/build/mech_converter.py
+++ b/build/mech_converter.py
@@ -463,7 +463,6 @@ end module mechanism_mod
             # This code only executes if the break is NOT called, i.e. if the loop runs to completion without the RO2 being
             # found in the species list
             else:
-                error_message = ' ****** Warning: RO2 species "' + str(ro2List_i.strip()) + '" NOT found in the mechanism. Please check the RO2 section of your mechansm file for incorrect species names! ******'
                 error_message = ''.join([
                   ' ****** ',
                   'Error: RO2 species "',


### PR DESCRIPTION
Adds an exception where an RO2 species is encountered in the RO2 sum of the mechanism file but isn't encountered in the mechanism species list.

We shouldn't get to a point where there is an RO2 species in mechanism.ro2 that isn't in the full species list in the mechanism, so I think the user needs to correct their mechanism before building and running the model, as opposed to a warning being shown and them being allowed to erroneously continue.

I had a look at adding some error handling to the `ro2Sum` function in `outputFunctions.f90` - it is a `pure` function which disallows `error stop`. I think there would be a bit too much unpicking to make that error handling neat, so I avoided it.

Let me know what you think - happy to make changes as requested.

Closes #453 