### PR TITLE
Fixed input and output of constant photolysis rates

### DIFF
--- a/src/inputFunctions.f90
+++ b/src/inputFunctions.f90
@@ -338,7 +338,6 @@ contains
     end if
 
     open (10, file=filename, status='old', iostat=ierr)
-    read (10,*) ! Ignore first line
     do i = 1, numConstantPhotoRates
       read (10,*, iostat=ierr) constantPhotoNumbers(i), constantPhotoValues(i), constantPhotoNames(i)
       if ( ierr /= 0 ) then
@@ -348,13 +347,13 @@ contains
     close (10, status='keep')
 
     if ( numConstantPhotoRates > 3 ) then
-      write (*, '(I7, 1P e15.3, 1P e15.3)') constantPhotoNumbers(1), constantPhotoValues(1), constantPhotoNames(1)
+      write (*, '(I7, 1P e15.3, A)') constantPhotoNumbers(1), constantPhotoValues(1), constantPhotoNames(1)
       write (*, '(A)') ' ...'
-      write (*, '(I7, 1P e15.3, 1P e15.3)') constantPhotoNumbers(numConstantPhotoRates), &
+      write (*, '(I7, 1P e15.3, A)') constantPhotoNumbers(numConstantPhotoRates), &
                                             constantPhotoValues(numConstantPhotoRates), constantPhotoNames(numConstantPhotoRates)
     else
       do i = 1, numConstantPhotoRates
-        write (*, '(I7, 1P e15.3, 1P e15.3)') constantPhotoNumbers(i), constantPhotoValues(i), constantPhotoNames(i)
+        write (*, '(I7, 1P e15.3, A)') constantPhotoNumbers(i), constantPhotoValues(i), constantPhotoNames(i)
       end do
     end if
     write (*, '(A)') ' Finished reading photolysis constants.'

--- a/src/outputFunctions.f90
+++ b/src/outputFunctions.f90
@@ -128,8 +128,8 @@ contains
   ! Write photolysis rates to file.
   subroutine outputPhotolysisRates( t )
     use types_mod
-    use photolysis_rates_mod, only : ck, constrainedPhotoNumbers, j, PR_type, &
-                                     constantPhotoNames, numConstantPhotoRates, &
+    use photolysis_rates_mod, only : ck, constrainedPhotoNumbers, constantPhotoNumbers, &
+                                     j, PR_type, constantPhotoNames, numConstantPhotoRates, &
                                      constrainedPhotoNames, numConstrainedPhotoRates, &
                                      unconstrainedPhotoNames, numUnconstrainedPhotoRates
 
@@ -145,7 +145,7 @@ contains
           write (58, '(100A15) ') 't', (trim( constantPhotoNames(i) ), i = 1_NPI, numConstantPhotoRates)
           firstTime = .false.
         end if
-        write (58, '(100 (ES15.6E3)) ') t, (j(ck(i)), i = 1_NPI, numConstantPhotoRates)
+        write (58, '(100 (ES15.6E3)) ') t, (j(constantPhotoNumbers(i)), i = 1_NPI, numConstantPhotoRates)
 
       case ( 2_SI )
         if ( firstTime .eqv. .true. ) then


### PR DESCRIPTION
Following discussion in #372.

I have also removed the ignoring of the first line in the `photolysisConstant.config` file, when read by `inputFunctions.f90`.

Changing the `inputFunctions.f90` file as discussed in #372 resulted in issues with the `outputFunctions.f90` file, which I believe I have also fixed. 
It's worth noting that when using at least one constant J value only the constant J values are output in the `photolysisRates.output` file. I assumed this was by design since the `photolysisConstant.config` overrides other photolysis rates and sets them to 0 (even if they are specified as constrained), e.g. giving a value of 1E-5 for J1 in `photolysisConstant.config` and listing J2 in `photolysisConstrained.config` will result in a model where J1 = 1E-5 throughout and J2 = 0, regardless of what the J2 constraint file says.

Hopefully this is all OK and makes sense, let me know if there's anything else that needs changing.