### PR TITLE
Correcting Rate Output for Non-integer Stoichiometry

### DIFF
--- a/src/atchem2.f90
+++ b/src/atchem2.f90
@@ -225,7 +225,7 @@ PROGRAM ATCHEM2
   allocate (detailedRatesSpecies(size( detailedRatesSpeciesName )))
   allocate (reacDetailedRatesSpecies(size( detailedRatesSpeciesName ), size( clhs, 2 )))
   allocate (prodDetailedRatesSpecies(size( detailedRatesSpeciesName ), size( crhs, 2 )))
-  invalid_reaction_frequency_pair = reaction_frequency_pair(-1_NPI, 0_NPI)
+  invalid_reaction_frequency_pair = reaction_frequency_pair(-1_NPI, 0_NPI, 0.0_DP)
   reacDetailedRatesSpecies(:,:) = invalid_reaction_frequency_pair
   prodDetailedRatesSpecies(:,:) = invalid_reaction_frequency_pair
   allocate (reacDetailedRatesSpeciesLengths(size( detailedRatesSpeciesName )))
@@ -243,8 +243,10 @@ PROGRAM ATCHEM2
   !
   ! Fill the remaining elements of each row of reac/prodDetailedRatesSpecies with the
   ! numbers of the reactions in which that species appears as a reactant/product respectively
-  call findReactionsWithProductOrReactant( detailedRatesSpecies, clhs, reacDetailedRatesSpecies, reacDetailedRatesSpeciesLengths )
-  call findReactionsWithProductOrReactant( detailedRatesSpecies, crhs, prodDetailedRatesSpecies, prodDetailedRatesSpeciesLengths )
+  call findReactionsWithProductOrReactant( detailedRatesSpecies, clhs, clcoeff, reacDetailedRatesSpecies, &
+                                           reacDetailedRatesSpeciesLengths )
+  call findReactionsWithProductOrReactant( detailedRatesSpecies, crhs, crcoeff, prodDetailedRatesSpecies, &
+                                           prodDetailedRatesSpeciesLengths )
   write (*, '(A, I0)') ' Species requiring detailed rate output (number of species found): ', size( detailedRatesSpeciesName )
   write (*,*)
 

--- a/src/configFunctions.f90
+++ b/src/configFunctions.f90
@@ -83,14 +83,16 @@ contains
   ! At the end of this function, each row of r is associated to one of
   ! the species in rSpecies. Each element of the row corresponds to a
   ! reaction in which this species appears as a product or reactant.
-  ! Each element consists of %reaction holding the reaction number, and
+  ! Each element consists of %reaction holding the reaction number,
   ! %frequency holding the number of occurences of that species in that
-  ! reaction. chs contains the product or reactant information, and
+  ! reaction, and %stoich holding the sum of the stoichiometric coefficients 
+  ! for that species in that reaction. chs contains the product or reactant information, and
   ! arrayLen is used to keep track of how many are present in each row.
-  subroutine findReactionsWithProductOrReactant( rSpecies, chs, r, arrayLen )
+  subroutine findReactionsWithProductOrReactant( rSpecies, chs, ccoeff, r, arrayLen )
     use types_mod
 
-    integer(kind=NPI), intent(in) :: rSpecies(:), chs(:,:)
+    integer(kind=NPI), intent(in) :: rSpecies(:), chs(:,:) 
+    real(kind=DP), intent(in) :: ccoeff(:)
     type(reaction_frequency_pair), intent(inout) :: r(:,:)
     integer(kind=NPI), intent(out) :: arrayLen(:)
     integer(kind=NPI) :: rCounter, i, j
@@ -125,6 +127,7 @@ contains
           end if
           r(i, rCounter)%reaction = chs(1, j)
           r(i, rCounter)%frequency = r(i, rCounter)%frequency + 1_NPI
+          r(i, rCounter)%stoich = r(i, rCounter)%stoich + ccoeff(j)
         end if
       end do
       arrayLen(i) = rCounter

--- a/src/dataStructures.f90
+++ b/src/dataStructures.f90
@@ -43,6 +43,7 @@ module types_mod
   type reaction_frequency_pair
     integer(kind=NPI) :: reaction
     integer(kind=NPI) :: frequency
+    real(kind=DP) :: stoich
   end type reaction_frequency_pair
 
   interface operator (==)


### PR DESCRIPTION
I recently noticed that the rate output was incorrect from models using a mechanism with stoichiometric coefficients (as was facilitated by #514). The actual rate of the reaction (as used in calculations) seems to be correct, but the stoichiometry was not accounted for when reporting the rate in the `lossRates.output` and `productionRates.output` files. For example, the production rate of `B` in the reaction `A = B + B` would be output differently from the reaction `A = 2B`, despite the concentrations of B in each model being identical. The production rate of B would be half what it should be in `A = 2B` because the stoichiometry was ignored.

Looking into `src/outputFunctions.f90` it looks like the outputted production/loss rate value was calculated by multiplying by the number of occurrences of a compound in a reaction by the reaction rate. This worked fine for the integer stoichiometry required prior to #514 , but now fails to account for instances where a compound may only appear once in a reaction, but with a stoichiometric coefficient. 

I have added a tracker of stoichiometry to the `reaction_frequency_pair` type and then used this to calculate the correct rate in `src/outputFunctions.f90`. My changes do make `reaction_frequency_pair` a slightly unintuitive name, so we could change this if needed. In fact, I believe that the frequency value in this type was only used for the rate output anyway, so we could maybe remove that.

Let me know if you have any questions.
Thanks,
Alfie