### PR TITLE
Setup for species injection

### DIFF
--- a/build/mech_converter.py
+++ b/build/mech_converter.py
@@ -40,7 +40,7 @@ import kpp_conversion
 
 reservedSpeciesList = ['N2', 'O2', 'M', 'RH', 'H2O', 'BLHEIGHT', 'DEC', 'JFAC',
                        'DILUTE', 'ROOF', 'ASA', 'RO2']
-reservedOtherList = ['EXP', 'TEMP', 'PRESS', 'LOG10', 'T', 'J', 't']
+reservedOtherList = ['EXP', 'LOG10', 'TEMP', 'PRESS', 'J', 't']
 
 # =========================== FUNCTIONS =========================== #
 

--- a/build/mech_converter.py
+++ b/build/mech_converter.py
@@ -40,8 +40,7 @@ import kpp_conversion
 
 reservedSpeciesList = ['N2', 'O2', 'M', 'RH', 'H2O', 'BLHEIGHT', 'DEC', 'JFAC',
                        'DILUTE', 'ROOF', 'ASA', 'RO2']
-reservedOtherList = ['EXP', 'TEMP', 'PRESS', 'LOG10', 'T', 'J']
-
+reservedOtherList = ['EXP', 'TEMP', 'PRESS', 'LOG10', 'T', 'J', 't']
 
 # =========================== FUNCTIONS =========================== #
 
@@ -558,12 +557,12 @@ module mechanism_mod
 
 contains
 
-    subroutine update_p(p, q, TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J, RO2) bind(c,name='update_p')
+    subroutine update_p(p, q, t, TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J, RO2) bind(c,name='update_p')
 
         use custom_functions_mod
         integer, parameter :: DP = selected_real_kind( p = 15, r = 307 )
-           real(c_double), intent(inout) :: p(*), q(*)
-        real(c_double), intent(in) :: TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J(*), RO2
+        real(c_double), intent(inout) :: p(*), q(*)
+        real(c_double), intent(in) :: t, TEMP, N2, O2, M, RH, H2O, BLHEIGHT, DEC, JFAC, DILUTE, ROOFOPEN, ASA, J(*), RO2
         """)
 
         # Write out 'Generic Rate Coefficients' and 'Complex reactions'.

--- a/src/solverFunctions.f90
+++ b/src/solverFunctions.f90
@@ -23,10 +23,10 @@ module solver_functions_mod
 
   ! Define interface of call-back routine.
   abstract interface
-    subroutine called_proc( i, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16 ) bind ( c )
+    subroutine called_proc( i, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17 ) bind ( c )
       use, intrinsic :: iso_c_binding
       real(c_double), intent(inout) :: i(*), i2(*)
-      real(c_double), intent(in) :: i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15(*), i16
+      real(c_double), intent(in) :: i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16(*), i17
     end subroutine called_proc
   end interface
 
@@ -256,7 +256,7 @@ contains
     !TODO: is this necessary a second time?
     ro2 = ro2sum( y )
 
-    call proc( p, q, temp, n2, o2, m, rh, h2o, blheight, dec, jfac, dilute, roofOpen, asa, j, ro2 )
+    call proc( p, q, t, temp, n2, o2, m, rh, h2o, blheight, dec, jfac, dilute, roofOpen, asa, j, ro2 )
 
     return
   end subroutine mechanism_rates

--- a/tests/makefile.tests
+++ b/tests/makefile.tests
@@ -17,7 +17,7 @@
 #
 # The following variables are defined in the main Makefile:
 # - $FRUITDIR is the path to FRUIT, the FORTRAN Unit Test Framework
-# - $UNITTEST_SRCS are the Fortran source files needed for the unit tests
+# - $CORE_SRCS are the Fortran source files needed for the unit tests
 # - $FORT_COMP is the Fortran compiler
 
 # ==================== Unit tests ==================== #
@@ -25,7 +25,7 @@
 # setup FRUIT
 UNITTESTDIR = tests/unit_tests
 fruit_code = $(FRUITDIR)/src/fruit.f90
-unittest_code = $(UNITTEST_SRCS) $(shell ls tests/unit_tests/*_test.f90 )
+unittest_code = $(CORE_SRCS) $(shell ls tests/unit_tests/*_test.f90 )
 unittest_code_gen = $(UNITTESTDIR)/fruit_basket_gen.f90 $(UNITTESTDIR)/fruit_driver_gen.f90
 all_unittest_code = $(fruit_code) $(unittest_code) $(unittest_code_gen)
 fruit_driver = $(UNITTESTDIR)/fruit_driver.exe

--- a/tests/model_tests/spec_model_func/configuration/customRateFuncs.f90
+++ b/tests/model_tests/spec_model_func/configuration/customRateFuncs.f90
@@ -26,13 +26,13 @@ contains
 
   ! -----------------------------------------------------------------
   ! Calculates the rate of KMT15
-  pure function calcKMT15( t, m ) result ( KMT15 )
-    real*8, intent(in) :: t, m
+  pure function calcKMT15( temp, m ) result ( KMT15 )
+    real*8, intent(in) :: temp, m
     real :: K150, K15I, KR15, FC15, NC15, F15
     real :: KMT15
 
-    K150 = 8.6E-29 * m * (t / 300)**(-3.1)
-    K15I = 9.0E-12 * (t / 300)**(-0.85)
+    K150 = 8.6E-29 * m * (temp / 300)**(-3.1)
+    K15I = 9.0E-12 * (temp / 300)**(-0.85)
     KR15 = K150 / K15I
     FC15 = 0.48
     NC15 = 0.75 - 1.27 * (LOG10(FC15))

--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -14,20 +14,20 @@
 
 # ==================== Makefile for AtChem2 ==================== #
 
-# choose the Fortran compiler
+# Choose the Fortran compiler
 # 1. "gnu" for gfortran (DEFAULT)
 # 2. "intel" for ifort
 FORTC = "gnu"
 
-# set the dependencies paths
-# N.B.: use the FULL PATHS, not the relative paths
+# Set the dependencies paths. Use full paths, not relative paths. For
+# example: `$(HOME)/path/to/dependencies/directory/cvode/lib`
 CVODELIBDIR = cvode/lib
 OPENLIBMDIR = openlibm
 FRUITDIR    = fruit_3.4.3
 
-# default location of the chemical mechanism shared library (`mechanism.so`)
-# use the second argument of the build script (`build/build_atchem2.sh`) to
-# override $SHAREDLIBDIR
+# Set the default location of the chemical mechanism shared library
+# (`mechanism.so`). Use the second argument of the build script
+# (`build/build_atchem2.sh`) to override $SHAREDLIBDIR
 SHAREDLIBDIR = model/configuration
 
 # =========================================================================== #
@@ -99,12 +99,12 @@ SRC = src
 # executable
 AOUT = atchem2
 
-# source files
-UNITTEST_SRCS = $(SRC)/dataStructures.f90 $(SRC)/argparse.f90 $(SRC)/interpolationFunctions.f90 \
+# fortran source files
+CORE_SRCS = $(SRC)/dataStructures.f90 $(SRC)/argparse.f90 $(SRC)/interpolationFunctions.f90 \
                 $(SRC)/configFunctions.f90 $(SRC)/inputFunctions.f90 $(SRC)/outputFunctions.f90 \
                 $(SRC)/atmosphereFunctions.f90 $(SRC)/solarFunctions.f90 $(SRC)/constraintFunctions.f90 \
                 $(SRC)/solverFunctions.f90 $(SRC)/parameterModules.f90
-SRCS = $(UNITTEST_SRCS) $(SRC)/atchem2.f90
+SRCS = $(CORE_SRCS) $(SRC)/atchem2.f90
 
 # prerequisite is $SRCS, so this will be rebuilt every time any source
 # file in $SRCS is changed

--- a/tools/install/Makefile.skel
+++ b/tools/install/Makefile.skel
@@ -44,7 +44,7 @@ OS := $(shell uname -s)
 # if on GitHub Actions
 ifeq ($(GITHUB_ACTIONS),true)
   ifeq ($(RUNNER_OS),Linux)
-    # if linux, pass gfortran
+    # if Linux, pass gfortran
     FORT_COMP    = gfortran-$(FORT_VERSION)
     FORT_LIB     = ""
   else
@@ -119,19 +119,24 @@ include tests/makefile.tests
 all: $(AOUT)
 
 sharedlib:
-	$(FORT_COMP) -c $(SHAREDLIBDIR)/customRateFuncs.f90 $(FSHAREDFLAGS) -o $(SHAREDLIBDIR)/customRateFuncs.o -J$(OBJ)
-	$(FORT_COMP) -c $(SHAREDLIBDIR)/mechanism.f90 $(FSHAREDFLAGS) -o $(SHAREDLIBDIR)/mechanism.o -J$(OBJ)
-	$(FORT_COMP) -shared -o $(SHAREDLIBDIR)/mechanism.so $(SHAREDLIBDIR)/mechanism.o $(SHAREDLIBDIR)/customRateFuncs.o
+	$(FORT_COMP) -c $(SRC)/dataStructures.f90 $(FSHAREDFLAGS) -o $(SRC)/dataStructures.o -J$(OBJ) -I$(OBJ)
+	$(FORT_COMP) -c $(SHAREDLIBDIR)/customRateFuncs.f90 $(FSHAREDFLAGS) -o $(SHAREDLIBDIR)/customRateFuncs.o -J$(OBJ) -I$(OBJ)
+	$(FORT_COMP) -c $(SHAREDLIBDIR)/mechanism.f90 $(FSHAREDFLAGS) -o $(SHAREDLIBDIR)/mechanism.o -J$(OBJ) -I$(OBJ)
+	$(FORT_COMP) -shared -o $(SHAREDLIBDIR)/mechanism.so $(SRC)/dataStructures.o $(SHAREDLIBDIR)/customRateFuncs.o $(SHAREDLIBDIR)/mechanism.o
 
 clean:
 	rm -f $(AOUT)
 	rm -f $(OBJ)/*.mod
 	rm -rf build/__pycache__
 	rm -f *.gcda *.gcno *.xml build/*.pyc tests/*.log
-	rm -f doc/figures/*.png doc/latex/*.aux doc/latex/*.bbl doc/latex/*.blg doc/latex/*.log doc/latex/*.out doc/latex/*.toc
-	rm -f model/configuration/mechanism.{f90,o,prod,reac,ro2,so,species} model/output/*.output model/output/reactionRates/*[0-9]
-	rm -f tests/tests/*/*.out tests/tests/*/model/configuration/mechanism.{f90,o,prod,reac,ro2,so,species} tests/tests/*/output/*.output tests/tests/*/output/reactionRates/*[0-9]
-	rm -f $(MODELTESTDIR)/*/*.out $(MODELTESTDIR)/*/configuration/mechanism.{f90,o,prod,reac,ro2,so,species} $(MODELTESTDIR)/*/output/*.output $(MODELTESTDIR)/*/output/reactionRates/*[0-9]
+	rm -f doc/figures/*.png doc/latex/*.aux doc/latex/*.bbl doc/latex/*.blg doc/latex/*.log \
+              doc/latex/*.out doc/latex/*.toc
+	rm -f model/configuration/mechanism.{f90,o,prod,reac,ro2,so,species} \
+              model/output/*.output model/output/reactionRates/*[0-9]
+	rm -f tests/tests/*/*.out tests/tests/*/model/configuration/mechanism.{f90,o,prod,reac,ro2,so,species} \
+              tests/tests/*/output/*.output tests/tests/*/output/reactionRates/*[0-9]
+	rm -f $(MODELTESTDIR)/*/*.out $(MODELTESTDIR)/*/configuration/mechanism.{f90,o,prod,reac,ro2,so,species} \
+              $(MODELTESTDIR)/*/output/*.output $(MODELTESTDIR)/*/output/reactionRates/*[0-9]
 	rm -f $(UNITTESTDIR)/fruit_*_gen.f90 $(UNITTESTDIR)/fruit_generator.rb $(fruit_driver)
 
 # ==================== Dependencies ==================== #


### PR DESCRIPTION
This modifies the `mechanism.f90` file to accept time (`t`) as a variable. It is necessary to specify when the injection of one or mre species occurs, but in general allows to write time-dependent functions using `customRateFunctions.f90`.